### PR TITLE
Stop excluding DunkinNet.png from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,3 @@ memory
 *.log
 README.md
 LICENSE
-DunkinNet.png


### PR DESCRIPTION
The .dockerignore was excluding DunkinNet.png on the assumption it was unused, but it's referenced in index.html, dishes.html, and grocery.html as the header logo.