### PR TITLE
Multi-user families + full UI redesign

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,156 @@
+// Shared client utilities — toasts, fetch wrapper, modal helpers, auth.
+
+export const api = {
+    async request(path, opts = {}) {
+        const headers = { 'Accept': 'application/json', ...(opts.headers || {}) };
+        if (opts.body && typeof opts.body !== 'string') {
+            headers['Content-Type'] = 'application/json';
+            opts.body = JSON.stringify(opts.body);
+        }
+        const res = await fetch(path, { credentials: 'same-origin', ...opts, headers });
+        const ct = res.headers.get('content-type') || '';
+        const data = ct.includes('application/json') ? await res.json().catch(() => null) : null;
+        if (!res.ok) {
+            if (res.status === 401) {
+                if (!location.pathname.startsWith('/login')) {
+                    location.href = '/login';
+                }
+            }
+            const msg = (data && data.error) || `Request failed (${res.status})`;
+            const err = new Error(msg);
+            err.status = res.status;
+            err.data = data;
+            throw err;
+        }
+        return data;
+    },
+    get: (p) => api.request(p),
+    post: (p, body) => api.request(p, { method: 'POST', body }),
+    put: (p, body) => api.request(p, { method: 'PUT', body }),
+    del: (p) => api.request(p, { method: 'DELETE' }),
+};
+
+// ─── Toasts ──────────────────────────────────────────────────────────
+
+let toastHost;
+function ensureToastHost() {
+    if (toastHost) return toastHost;
+    toastHost = document.createElement('div');
+    toastHost.className = 'toast-host';
+    document.body.appendChild(toastHost);
+    return toastHost;
+}
+
+export function toast(message, type = 'info', duration = 2800) {
+    const host = ensureToastHost();
+    const el = document.createElement('div');
+    el.className = `toast ${type}`;
+    el.textContent = message;
+    host.appendChild(el);
+    requestAnimationFrame(() => el.classList.add('show'));
+    setTimeout(() => {
+        el.classList.remove('show');
+        setTimeout(() => el.remove(), 240);
+    }, duration);
+}
+
+// ─── Capitalization helper ──────────────────────────────────────────
+
+export function capitalizeWords(str) {
+    if (!str) return '';
+    return str
+        .split(' ')
+        .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1).toLowerCase() : ''))
+        .join(' ');
+}
+
+// ─── Modal helpers ──────────────────────────────────────────────────
+
+export function openModal(el) {
+    if (!el) return;
+    el.classList.add('open');
+    document.body.style.overflow = 'hidden';
+}
+export function closeModal(el) {
+    if (!el) return;
+    el.classList.remove('open');
+    document.body.style.overflow = '';
+}
+export function bindModalDismiss(modal, ...closers) {
+    if (!modal) return;
+    closers.forEach((c) => c && c.addEventListener('click', () => closeModal(modal)));
+    modal.addEventListener('click', (e) => {
+        if (e.target === modal) closeModal(modal);
+    });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && modal.classList.contains('open')) closeModal(modal);
+    });
+}
+
+// ─── Header + bottom nav builders ───────────────────────────────────
+
+export function renderHeader({ title, icon = 'fa-utensils', user } = {}) {
+    const header = document.querySelector('header.app-header');
+    if (!header) return;
+    header.innerHTML = `
+      <div class="brand">
+        <div class="brand-icon"><i class="fas ${icon}"></i></div>
+        <h1>${title || 'MealFinderrz'}</h1>
+      </div>
+      <div class="header-actions">
+        ${user
+            ? `<a href="/family" class="icon-btn" title="Family"><i class="fas fa-people-roof"></i></a>
+               <button id="logoutBtn" class="icon-btn" title="Log out"><i class="fas fa-sign-out-alt"></i></button>`
+            : ''}
+      </div>
+    `;
+    const logoutBtn = header.querySelector('#logoutBtn');
+    if (logoutBtn) {
+        logoutBtn.addEventListener('click', async () => {
+            try {
+                await api.post('/api/auth/logout', {});
+            } finally {
+                location.href = '/login';
+            }
+        });
+    }
+}
+
+export function renderBottomNav(active) {
+    const nav = document.querySelector('nav.bottom-nav');
+    if (!nav) return;
+    const items = [
+        { key: 'dishes', href: '/dishes', icon: 'fa-book', label: 'Dishes' },
+        { key: 'home', href: '/', icon: 'fa-calendar-days', label: 'Calendar' },
+        { key: 'grocery', href: '/grocery', icon: 'fa-list-check', label: 'Grocery' },
+    ];
+    nav.innerHTML = items
+        .map(
+            (it) => `
+        <a href="${it.href}" class="${it.key === active ? 'active' : ''}" aria-label="${it.label}">
+          <i class="fas ${it.icon}"></i>
+          <span class="label">${it.label}</span>
+        </a>`
+        )
+        .join('');
+}
+
+// ─── Auth bootstrap ─────────────────────────────────────────────────
+
+export async function requireUser() {
+    try {
+        const { user } = await api.get('/api/auth/me');
+        if (!user) {
+            location.href = '/login';
+            return null;
+        }
+        if (!user.familyId && !location.pathname.startsWith('/family')) {
+            location.href = '/family';
+            return user;
+        }
+        return user;
+    } catch {
+        location.href = '/login';
+        return null;
+    }
+}

--- a/dishes.html
+++ b/dishes.html
@@ -1,142 +1,94 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dish Library</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Dish Library · MealFinderrz</title>
+    <link rel="stylesheet" href="styles.css?v=20" />
     <link rel="manifest" href="manifest.json" />
-    <link rel="stylesheet" href="styles.css?v=7">
+    <meta name="theme-color" content="#072444" />
+    <link rel="icon" href="icon-180x180.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-        integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
+          integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
-
 <body>
+    <header class="app-header"></header>
 
-    <header>
-        <h1><img src="launch.png" alt="Meals Icon"> Dish Library</h1>
-        <a href="https://dunkin.fun" class="header-logo-link">
-            <img src="DunkinNet.png" alt="DunkinNet" class="header-logo">
-        </a>
-    </header>
+    <main class="page">
+        <div class="toolbar">
+            <input id="dishSearch" type="search" class="search-input" placeholder="Search dishes…" />
+            <button id="manageTagsBtn" class="toolbar-btn" title="Manage tags"><i class="fas fa-tags"></i></button>
+            <button id="addDishBtn" class="toolbar-btn primary" title="Add dish"><i class="fas fa-plus"></i></button>
+        </div>
 
-    <div class="dish-library-management">
+        <div class="tag-filter-row" id="tagFilterRow"></div>
 
-        <div class="current-dishes-header">
-            <button id="openAddDishModal"><i class="fas fa-square-plus"></i></button>
-            <div class="filter-section">
-                <button id="openFilterPopup"><i class="fas fa-filter"></i></button>
-                <div id="filterPopup" class="tag-popup">
-                    <div class="popup-header">
-                        <button id="clearFilter">All</button>
-                    </div>
-                    <div id="tagButtonsContainer">
-                    </div>
-                    <div class="popup-footer">
-                        <button id="openAddTagPopup"><i class="fas fa-pencil"></i></button>
+        <div id="dishList" class="dish-grid"></div>
+    </main>
+
+    <!-- Add / Edit dish modal -->
+    <div class="modal" id="dishModal" role="dialog" aria-modal="true">
+        <div class="sheet">
+            <div class="sheet-grabber" aria-hidden="true"></div>
+            <div class="sheet-header">
+                <h3 id="dishModalTitle">New dish</h3>
+                <button class="sheet-close" id="closeDishModal" aria-label="Close">&times;</button>
+            </div>
+            <div class="sheet-body">
+                <div class="field">
+                    <label for="dishName">Dish name</label>
+                    <input type="text" id="dishName" class="input" placeholder="Spaghetti Bolognese" maxlength="80" />
+                </div>
+
+                <div>
+                    <label class="section-title" style="margin: 6px 0 8px;">Ingredients</label>
+                    <ul class="ingredient-list" id="ingredientList"></ul>
+                    <div class="field-row" style="margin-top: 8px;">
+                        <input type="text" id="ingName" class="input" placeholder="Ingredient" />
+                        <input type="text" id="ingQty" class="input" placeholder="Qty (e.g. 2 cups)" style="max-width: 130px;" />
+                        <button id="addIngBtn" class="toolbar-btn primary" title="Add ingredient" aria-label="Add ingredient"><i class="fas fa-plus"></i></button>
                     </div>
                 </div>
-            </div>
 
-            <div id="addTagPopup" class="modal">
-                <div class="modal-content">
-                    <span class="close-button" id="closeAddTagModal">&times;</span>
-                    <h3>Manage Tags</h3>
-                    <div class="add-new-tag">
-                        <label for="newTagName">New Tag:</label>
-                        <input type="text" id="newTagName" placeholder="New Tag Name">
-                        <button id="saveNewTagButton">Add Tag</button>
-                    </div>
-                    <h4>Existing Tags:</h4>
-                    <ul id="existingTagsList">
-                    </ul>
+                <div>
+                    <label class="section-title" style="margin: 6px 0 8px;">Tags</label>
+                    <ul class="chip-list" id="dishTagList"></ul>
+                    <select id="tagPicker" class="input" style="margin-top: 8px;">
+                        <option value="">Add a tag…</option>
+                    </select>
+                </div>
+
+                <div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:12px;">
+                    <button id="saveDishBtn" class="btn"><i class="fas fa-check"></i> Save dish</button>
+                    <button id="deleteDishBtn" class="btn btn-danger" style="display:none;"><i class="fas fa-trash-can"></i> Delete</button>
+                    <button class="btn btn-ghost" id="cancelDishBtn">Cancel</button>
                 </div>
             </div>
-
         </div>
-        <div id="dishListContainer" class="dish-grid">
-        </div>
+    </div>
 
-        <div id="addDishModal" class="modal">
-            <div class="modal-content">
-                <span class="close-button" id="closeAddModal">&times;</span>
-                <h3>Add New Dish</h3>
-                <label for="newDishName">Dish Name:</label>
-                <input type="text" id="newDishName" placeholder="Dish Name">
-
-                <h4>Ingredients:</h4>
-                <div class="add-ingredient">
-                    <input type="text" id="newDishIngredientName" placeholder="Ingredient Name">
-                    <input type="text" id="newDishIngredientQuantity" placeholder="Quantity">
-                    <button id="addDishWithIngredientsButton"><i class="fas fa-plus"></i></button>
+    <!-- Manage Tags modal -->
+    <div class="modal" id="tagModal" role="dialog" aria-modal="true">
+        <div class="sheet">
+            <div class="sheet-grabber" aria-hidden="true"></div>
+            <div class="sheet-header">
+                <h3>Manage tags</h3>
+                <button class="sheet-close" id="closeTagModal" aria-label="Close">&times;</button>
+            </div>
+            <div class="sheet-body">
+                <div class="field-row">
+                    <input id="newTagName" class="input" placeholder="vegetarian" maxlength="32" />
+                    <button id="saveTagBtn" class="btn btn-yellow"><i class="fas fa-plus"></i> Add</button>
                 </div>
-                <ul id="ingredientsList">
-                </ul>
-
-                <h4>Tags:</h4>
-                <select id="availableTags">
-                    <option value="">Add a tag</option>
-                </select>
-                <ul id="selectedTagsList"></ul>
-                <button id="addDishButton">Save Dish</button>
-
-
+                <ul class="chip-list" id="existingTagsList"></ul>
             </div>
         </div>
     </div>
 
+    <nav class="bottom-nav"></nav>
 
-    <div id="dishListContainer" class="dish-grid">
-    </div>
-
-    <div id="editDishModal" class="modal">
-        <div class="modal-content">
-            <span class="close-button" id="closeEditModal">&times;</span>
-            <h3>Edit Dish</h3>
-            <label for="editDishName">Dish Name:</label>
-            <input type="text" id="editDishName">
-
-            <h4>Ingredients:</h4>
-            <ul id="editIngredientsList">
-            </ul>
-            <div class="add-ingredient">
-                <input type="text" id="editNewIngredientName" placeholder="Ingredient Name">
-                <input type="text" id="editNewIngredientQuantity" placeholder="Quantity">
-                <button id="editAddIngredientButton"><i class="fas fa-plus"></i></button>
-            </div>
-            <h4>Tags:</h4>
-            <div class="add-tag">
-                <select id="editAvailableTags">
-                    <option value="">Add a tag</option>
-                </select>
-            </div>
-            <ul id="editSelectedTagsList"></ul>
-
-            <button id="saveEditedDishButton">Save Changes</button>
-            <button id="deleteEditedDishButton">Delete Dish</button>
-            <input type="hidden" id="currentDishId">
-        </div>
-    </div>
-    </div>
-
-    <div class="bottom-navigation">
-        <div class="bottom-buttons">
-            <div class="active-dish-button">
-                <button id="active-dishLibraryButton">
-                    <i class="fas fa-book"></i>
-                </button>
-            </div>
-            <button id="homeButton" onclick="window.location.href='index.html'">
-                <i class="fas fa-home"></i>
-            </button>
-            <button id="groceryListButton" onclick="window.location.href='grocery.html'">
-                <i class="fas fa-list-check"></i>
-            </button>
-        </div>
-    </div>
-
-    <script src="dishes.js" type="module"></script>
+    <script type="module" src="dishes.js?v=20"></script>
 </body>
-
 </html>

--- a/dishes.js
+++ b/dishes.js
@@ -1,747 +1,328 @@
-// dishes.js
+import { api, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser } from './app.js?v=20';
 
-const API_URL = '/api';
+let allDishes = [];
+let allTags = [];
+let activeTagFilter = '';
+let searchQuery = '';
+let editingDish = null; // null when adding
+let workingIngredients = {}; // { id: {name, quantity, haveIt} }
+let workingTags = []; // [name]
 
-// --- DOM Elements ---
-const dishListContainer = document.getElementById('dishListContainer');
-const addDishModal = document.getElementById('addDishModal');
-const closeAddModalButton = document.getElementById('closeAddModal');
-const newDishNameInput = document.getElementById('newDishName');
-const newDishIngredientNameInput = document.getElementById('newDishIngredientName');
-const newDishIngredientQuantityInput = document.getElementById('newDishIngredientQuantity');
-const addIngredientButton = document.getElementById('addIngredientButton');
-const ingredientsList = document.getElementById('ingredientsList');
-const addDishButton = document.getElementById('addDishButton');
+const els = {};
 
-const editDishModal = document.getElementById('editDishModal');
-const closeEditModalButton = document.getElementById('closeEditModal');
-const editDishNameInput = document.getElementById('editDishName');
-const editIngredientsList = document.getElementById('editIngredientsList');
-const editNewIngredientNameInput = document.getElementById('editNewIngredientName');
-const editNewIngredientQuantityInput = document.getElementById('editNewIngredientQuantity');
-const editAddIngredientButton = document.getElementById('editAddIngredientButton');
-const saveEditedDishButton = document.getElementById('saveEditedDishButton');
-const currentDishIdInput = document.getElementById('currentDishId');
-
-const availableTagsAddDish = document.getElementById('availableTags');
-const availableTagsEditDish = document.getElementById('editAvailableTags');
-const selectedTagsList = document.getElementById('selectedTagsList');
-const editSelectedTagsList = document.getElementById('editSelectedTagsList');
-
-const openFilterPopupButton = document.getElementById('openFilterPopup');
-const filterPopup = document.getElementById('filterPopup');
-const tagButtonsContainer = document.getElementById('tagButtonsContainer');
-const closeFilterPopupButton = document.getElementById('closeFilterPopup');
-const clearFilterButton = document.getElementById('clearFilter');
-
-const openAddTagPopupButton = document.getElementById('openAddTagPopup');
-const addTagPopup = document.getElementById('addTagPopup');
-const closeAddTagModalButton = document.getElementById('closeAddTagModal');
-const newTagNameInput = document.getElementById('newTagName');
-const saveNewTagButton = document.getElementById('saveNewTagButton');
-const existingTagsList = document.getElementById('existingTagsList');
-
-const openAddDishModalButton = document.getElementById('openAddDishModal');
-const addDishWithIngredientsButton = document.getElementById('addDishWithIngredientsButton');
-
-
-// --- State Variables ---
-let currentIngredients = [];
-let editingIngredients = {};
-let currentTags = [];
-let editingTags = [];
-let currentFilterTag = '';
-let allLoadedDishes = [];
-let currentlyEditingIngredientKey = null;
-
-// --- Utility Functions ---
-
-function capitalizeWords(str) {
-    if (!str) return '';
-    return str.split(' ')
-        .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-        .join(' ');
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-// --- Add Dish Modal Functions ---
-
-function resetAddDishForm() {
-    newDishNameInput.value = '';
-    newDishIngredientNameInput.value = '';
-    newDishIngredientQuantityInput.value = '';
-    ingredientsList.innerHTML = '';
-    selectedTagsList.innerHTML = '';
-    availableTagsAddDish.selectedIndex = 0;
-    currentIngredients = [];
-    currentTags = [];
+async function loadAll() {
+    [allDishes, allTags] = await Promise.all([
+        api.get('/api/dishes').catch(() => []),
+        api.get('/api/tags').catch(() => []),
+    ]);
+    allDishes.sort((a, b) => a.name.localeCompare(b.name));
+    allTags.sort((a, b) => a.name.localeCompare(b.name));
+    renderTagFilter();
+    renderDishes();
 }
 
-function renderIngredientsList() {
-    if (!ingredientsList) return;
-    ingredientsList.innerHTML = '';
-    currentIngredients.forEach((ingredient, index) => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `
-            <div><i class="fas fa-carrot"></i> ${capitalizeWords(ingredient.name)} (${ingredient.quantity})</div>
-            <div>
-                <button class="remove-ingredient-button" data-index="${index}">&times;</button>
+function renderTagFilter() {
+    els.tagFilter.innerHTML = '';
+    const allChip = document.createElement('button');
+    allChip.className = `tag-chip ${activeTagFilter === '' ? 'active' : ''}`;
+    allChip.textContent = 'All';
+    allChip.addEventListener('click', () => {
+        activeTagFilter = '';
+        renderTagFilter();
+        renderDishes();
+    });
+    els.tagFilter.appendChild(allChip);
+
+    allTags.forEach((tag) => {
+        const chip = document.createElement('button');
+        chip.className = `tag-chip ${activeTagFilter === tag.name ? 'active' : ''}`;
+        chip.textContent = capitalizeWords(tag.name);
+        chip.addEventListener('click', () => {
+            activeTagFilter = activeTagFilter === tag.name ? '' : tag.name;
+            renderTagFilter();
+            renderDishes();
+        });
+        els.tagFilter.appendChild(chip);
+    });
+}
+
+function renderDishes() {
+    const q = searchQuery.toLowerCase();
+    let list = allDishes.filter((d) => {
+        if (activeTagFilter && !(d.tags || []).map((t) => t.toLowerCase()).includes(activeTagFilter.toLowerCase())) return false;
+        if (q) {
+            const inName = d.name.toLowerCase().includes(q);
+            const inTags = (d.tags || []).some((t) => t.toLowerCase().includes(q));
+            const inIng = Object.values(d.ingredients || {}).some((i) => (i.name || '').toLowerCase().includes(q));
+            if (!inName && !inTags && !inIng) return false;
+        }
+        return true;
+    });
+
+    if (list.length === 0) {
+        els.dishList.innerHTML = `
+            <div class="empty-state" style="grid-column: 1 / -1;">
+                <div class="icon"><i class="fas fa-utensils"></i></div>
+                <h3>${allDishes.length === 0 ? 'No dishes yet' : 'No matches'}</h3>
+                <p>${allDishes.length === 0 ? 'Add your first dish to start planning meals.' : 'Try a different search or filter.'}</p>
+                ${allDishes.length === 0 ? '<button class="btn" id="emptyAddBtn"><i class="fas fa-plus"></i> Add a dish</button>' : ''}
             </div>
         `;
-        ingredientsList.appendChild(listItem);
-    });
-    ingredientsList.querySelectorAll('.remove-ingredient-button').forEach(button => {
-        button.addEventListener('click', (e) => removeIngredient(parseInt(e.target.dataset.index)));
-    });
-}
-
-function addIngredientToList() {
-    const ingredientName = newDishIngredientNameInput.value.trim().toLowerCase();
-    const ingredientQuantity = newDishIngredientQuantityInput.value.trim();
-    if (ingredientName && ingredientQuantity) {
-        currentIngredients.push({ name: ingredientName, quantity: ingredientQuantity });
-        renderIngredientsList();
-        newDishIngredientNameInput.value = '';
-        newDishIngredientQuantityInput.value = '';
-        newDishIngredientNameInput.focus();
-    } else {
-        alert('Please enter both ingredient name and quantity.');
+        const empty = document.getElementById('emptyAddBtn');
+        if (empty) empty.addEventListener('click', () => openDishModal(null));
+        return;
     }
-}
 
-function removeIngredient(index) {
-    currentIngredients.splice(index, 1);
-    renderIngredientsList();
-}
-
-function renderSelectedTags() {
-    selectedTagsList.innerHTML = '';
-    currentTags.forEach((tag, index) => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `
-            <span><i class="fas fa-tag"></i> ${capitalizeWords(tag)}</span>
-            <button class="remove-tag-button" data-index="${index}"><i class="fas fa-times"></i></button>
+    els.dishList.innerHTML = '';
+    list.forEach((dish) => {
+        const card = document.createElement('button');
+        card.type = 'button';
+        card.className = 'dish-card';
+        const tags = (dish.tags || []).slice(0, 3).map((t) => `<span class="pill">${escapeHtml(capitalizeWords(t))}</span>`).join('');
+        card.innerHTML = `
+            <h3>${escapeHtml(capitalizeWords(dish.name))}</h3>
+            ${tags ? `<div class="dish-tags">${tags}</div>` : ''}
         `;
-        selectedTagsList.appendChild(listItem);
-    });
-    selectedTagsList.querySelectorAll('.remove-tag-button').forEach(button => {
-        button.addEventListener('click', (e) => removeTag(parseInt(e.currentTarget.dataset.index)));
+        card.addEventListener('click', () => openDishModal(dish));
+        els.dishList.appendChild(card);
     });
 }
 
-function addTagToList() {
-    const selectedTag = availableTagsAddDish.value;
-    if (selectedTag && !currentTags.includes(selectedTag)) {
-        currentTags.push(selectedTag);
-        renderSelectedTags();
+function openDishModal(dish) {
+    editingDish = dish;
+    els.dishModalTitle.textContent = dish ? 'Edit dish' : 'New dish';
+    els.dishName.value = dish ? dish.name : '';
+    workingIngredients = dish ? JSON.parse(JSON.stringify(dish.ingredients || {})) : {};
+    workingTags = dish ? [...(dish.tags || [])] : [];
+    renderIngredients();
+    renderWorkingTags();
+    populateTagPicker();
+    els.deleteDishBtn.style.display = dish ? '' : 'none';
+    openModal(els.dishModal);
+    setTimeout(() => els.dishName.focus(), 80);
+}
+
+function renderIngredients() {
+    els.ingList.innerHTML = '';
+    const entries = Object.entries(workingIngredients);
+    if (entries.length === 0) {
+        const li = document.createElement('li');
+        li.style.justifyContent = 'center';
+        li.style.color = 'var(--text-muted)';
+        li.style.fontStyle = 'italic';
+        li.textContent = 'No ingredients yet';
+        els.ingList.appendChild(li);
+        return;
     }
-    availableTagsAddDish.value = '';
-}
-
-function removeTag(index) {
-    currentTags.splice(index, 1);
-    renderSelectedTags();
-}
-
-function openAddDishModalHandler() {
-    resetAddDishForm();
-    populateTagDropdowns();
-    addDishModal.style.display = 'block';
-}
-
-function closeAddDishModalHandler() {
-    addDishModal.style.display = 'none';
-}
-
-// --- Edit Dish Modal Functions ---
-
-function clearEditDishForm() {
-    editDishNameInput.value = '';
-    editIngredientsList.innerHTML = '';
-    editSelectedTagsList.innerHTML = '';
-    editNewIngredientNameInput.value = '';
-    editNewIngredientQuantityInput.value = '';
-    availableTagsEditDish.selectedIndex = 0;
-    currentDishIdInput.value = '';
-    editingIngredients = {};
-    editingTags = [];
-    currentlyEditingIngredientKey = null;
-}
-
-function renderEditIngredientsList() {
-    editIngredientsList.innerHTML = '';
-    Object.entries(editingIngredients).forEach(([ingredientId, ingredient]) => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `
-            <div><i class="fas fa-caret-right"></i> ${capitalizeWords(ingredient.name)} (${ingredient.quantity})</div>
-            <div>
-                <button class="edit-ingredient-button" data-id="${ingredientId}"><i class="fas fa-pencil-alt"></i></button>
-                <button class="remove-ingredient-button" data-id="${ingredientId}">&times;</button>
-            </div>
+    entries.forEach(([id, ing]) => {
+        const li = document.createElement('li');
+        li.innerHTML = `
+            <span class="ing-name">${escapeHtml(capitalizeWords(ing.name))}</span>
+            <span class="ing-qty">${escapeHtml(ing.quantity || '')}</span>
+            <span class="actions">
+                <button data-action="remove" data-id="${id}" class="danger" title="Remove"><i class="fas fa-times"></i></button>
+            </span>
         `;
-        editIngredientsList.appendChild(listItem);
+        els.ingList.appendChild(li);
     });
-
-    editIngredientsList.querySelectorAll('.edit-ingredient-button').forEach(button => {
-        button.addEventListener('click', (e) => {
-            const id = e.currentTarget.dataset.id;
-            handleEditIngredient(id, editingIngredients[id].name, editingIngredients[id].quantity);
+    els.ingList.querySelectorAll('button[data-action="remove"]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            delete workingIngredients[btn.dataset.id];
+            renderIngredients();
         });
     });
-    editIngredientsList.querySelectorAll('.remove-ingredient-button').forEach(button => {
-        button.addEventListener('click', (e) => removeEditIngredient(e.currentTarget.dataset.id));
+}
+
+function addIngredient() {
+    const name = els.ingName.value.trim();
+    const qty = els.ingQty.value.trim();
+    if (!name) {
+        toast('Ingredient name required', 'error');
+        return;
+    }
+    const id = `ing-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    workingIngredients[id] = { name: name.toLowerCase(), quantity: qty || '1', haveIt: false };
+    els.ingName.value = '';
+    els.ingQty.value = '';
+    els.ingName.focus();
+    renderIngredients();
+}
+
+function renderWorkingTags() {
+    els.dishTagList.innerHTML = '';
+    workingTags.forEach((t, i) => {
+        const li = document.createElement('li');
+        li.innerHTML = `<i class="fas fa-tag" style="font-size:0.7rem;"></i> ${escapeHtml(capitalizeWords(t))} <button class="remove" data-i="${i}" aria-label="Remove tag">&times;</button>`;
+        els.dishTagList.appendChild(li);
+    });
+    els.dishTagList.querySelectorAll('.remove').forEach((b) => {
+        b.addEventListener('click', () => {
+            workingTags.splice(Number(b.dataset.i), 1);
+            renderWorkingTags();
+        });
     });
 }
 
-function handleEditIngredient(ingredientId, name, quantity) {
-    editNewIngredientNameInput.value = name;
-    editNewIngredientQuantityInput.value = quantity;
-    currentlyEditingIngredientKey = ingredientId;
-    editNewIngredientNameInput.focus();
+function populateTagPicker() {
+    els.tagPicker.innerHTML = '<option value="">Add a tag…</option>';
+    allTags.forEach((tag) => {
+        if (workingTags.includes(tag.name)) return;
+        const opt = document.createElement('option');
+        opt.value = tag.name;
+        opt.textContent = capitalizeWords(tag.name);
+        els.tagPicker.appendChild(opt);
+    });
 }
 
-function addOrUpdateEditIngredient() {
-    const ingredientName = editNewIngredientNameInput.value.trim().toLowerCase();
-    const ingredientQuantity = editNewIngredientQuantityInput.value.trim();
-
-    if (ingredientName && ingredientQuantity) {
-        if (currentlyEditingIngredientKey) {
-            editingIngredients[currentlyEditingIngredientKey].name = ingredientName;
-            editingIngredients[currentlyEditingIngredientKey].quantity = ingredientQuantity;
+async function saveDish() {
+    const name = els.dishName.value.trim();
+    if (!name) {
+        toast('Dish name is required', 'error');
+        return;
+    }
+    const payload = {
+        name,
+        ingredients: workingIngredients,
+        tags: workingTags.map((t) => t.toLowerCase()),
+    };
+    els.saveDishBtn.disabled = true;
+    try {
+        if (editingDish) {
+            await api.put(`/api/dishes/${editingDish.id}`, payload);
+            toast('Dish updated', 'success');
         } else {
-            const newId = `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-            editingIngredients[newId] = { name: ingredientName, quantity: ingredientQuantity, haveIt: false };
+            await api.post('/api/dishes', payload);
+            toast('Dish added', 'success');
         }
-        renderEditIngredientsList();
-        editNewIngredientNameInput.value = '';
-        editNewIngredientQuantityInput.value = '';
-        currentlyEditingIngredientKey = null;
-        editNewIngredientNameInput.focus();
-    }
-}
-
-function removeEditIngredient(ingredientId) {
-    delete editingIngredients[ingredientId];
-    renderEditIngredientsList();
-    if (currentlyEditingIngredientKey === ingredientId) {
-        editNewIngredientNameInput.value = '';
-        editNewIngredientQuantityInput.value = '';
-        currentlyEditingIngredientKey = null;
-    }
-}
-
-function renderEditSelectedTags() {
-    editSelectedTagsList.innerHTML = '';
-    editingTags.forEach((tag, index) => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `
-            <span><i class="fas fa-tag"></i> ${capitalizeWords(tag)}</span>
-            <button class="remove-tag-button" data-index="${index}"><i class="fas fa-times"></i></button>
-        `;
-        editSelectedTagsList.appendChild(listItem);
-    });
-
-    editSelectedTagsList.querySelectorAll('.remove-tag-button').forEach(button => {
-        button.addEventListener('click', (e) => removeEditTag(parseInt(e.currentTarget.dataset.index)));
-    });
-}
-
-function addEditTagToList() {
-    const selectedTag = availableTagsEditDish.value;
-    if (selectedTag && !editingTags.includes(selectedTag)) {
-        editingTags.push(selectedTag);
-        renderEditSelectedTags();
-    }
-    availableTagsEditDish.value = '';
-}
-
-function removeEditTag(index) {
-    editingTags.splice(index, 1);
-    renderEditSelectedTags();
-}
-
-function openEditModalHandler(dishId, dishName, ingredients, tags) {
-    clearEditDishForm();
-    populateTagDropdowns();
-
-    editDishNameInput.value = dishName;
-    currentDishIdInput.value = dishId;
-
-    editingIngredients = JSON.parse(JSON.stringify(ingredients || {}));
-    editingTags = Array.isArray(tags) ? [...tags] : [];
-
-    renderEditIngredientsList();
-    renderEditSelectedTags();
-
-    editDishModal.style.display = 'block';
-}
-
-function closeEditModalHandler() {
-    editDishModal.style.display = 'none';
-}
-
-// --- Tag Management Functions ---
-
-async function loadTagsFromAPI() {
-    try {
-        const response = await fetch(`${API_URL}/tags`);
-        if (!response.ok) throw new Error('Failed to fetch tags');
-        const tags = await response.json();
-        // Sort
-        tags.sort((a, b) => a.name.localeCompare(b.name));
-        return tags;
-    } catch (error) {
-        console.error("Error loading tags:", error);
-        return [];
-    }
-}
-
-async function populateTagDropdowns() {
-    const tags = await loadTagsFromAPI();
-    const optionsHtml = tags.map(tag =>
-        `<option value="${tag.name}">${capitalizeWords(tag.name)}</option>`
-    ).join('');
-
-    if (availableTagsAddDish) {
-        availableTagsAddDish.innerHTML = '<option value="" disabled selected>Add a tag...</option>' + optionsHtml;
-    }
-    if (availableTagsEditDish) {
-        availableTagsEditDish.innerHTML = '<option value="" disabled selected>Add a tag...</option>' + optionsHtml;
-    }
-}
-
-async function populateFilterTagButtons() {
-    const tags = await loadTagsFromAPI();
-    if (tagButtonsContainer) {
-        tagButtonsContainer.innerHTML = '';
-
-        const allButton = document.createElement('button');
-        allButton.textContent = 'All';
-        allButton.classList.add('tag-button');
-        allButton.addEventListener('click', () => applyFilterTag(''));
-        tagButtonsContainer.appendChild(allButton);
-
-        tags.forEach(tag => {
-            const button = document.createElement('button');
-            button.textContent = capitalizeWords(tag.name);
-            button.classList.add('tag-button');
-            button.dataset.tag = tag.name;
-            button.addEventListener('click', () => applyFilterTag(tag.name));
-            tagButtonsContainer.appendChild(button);
-        });
-    }
-}
-
-async function loadAndDisplayTagsForManagement() {
-    try {
-        const tags = await loadTagsFromAPI();
-        renderExistingTags(tags);
-    } catch (error) {
-        console.error("Error loading tags for management:", error);
-    }
-}
-
-function renderExistingTags(tags) {
-    existingTagsList.innerHTML = '';
-    tags.forEach(tag => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `
-            <span><i class="fas fa-tag"></i> ${capitalizeWords(tag.name)}</span>
-            <button class="delete-tag-button" data-id="${tag.id}"><i class="fas fa-times"></i></button>
-        `;
-        existingTagsList.appendChild(listItem);
-    });
-
-    existingTagsList.querySelectorAll('.delete-tag-button').forEach(button => {
-        button.addEventListener('click', (e) => deleteTagFromAPI(e.currentTarget.dataset.id));
-    });
-}
-
-async function saveTagToAPI() {
-    const newTagName = newTagNameInput.value.trim().toLowerCase();
-    if (newTagName) {
-        try {
-            const existingTags = await loadTagsFromAPI();
-            if (existingTags.some(tag => tag.name === newTagName)) {
-                alert(`Tag "${capitalizeWords(newTagName)}" already exists.`);
-                newTagNameInput.value = '';
-                return;
-            }
-
-            const response = await fetch(`${API_URL}/tags`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: newTagName })
-            });
-            if (!response.ok) throw new Error('Failed to save tag');
-
-            console.log("Tag added:", newTagName);
-            newTagNameInput.value = '';
-            await loadAndDisplayTagsForManagement();
-            await populateFilterTagButtons();
-            await populateTagDropdowns();
-        } catch (error) {
-            console.error("Error adding tag:", error);
-            alert("Failed to add tag.");
-        }
-    } else {
-        alert("Tag name cannot be empty.");
-    }
-}
-
-async function deleteTagFromAPI(tagId) {
-    if (!confirm('Are you sure you want to delete this tag? This cannot be undone.')) {
-        return;
-    }
-    try {
-        const response = await fetch(`${API_URL}/tags/${tagId}`, {
-            method: 'DELETE'
-        });
-        if (!response.ok) throw new Error('Failed to delete tag');
-
-        console.log("Tag deleted:", tagId);
-        await loadAndDisplayTagsForManagement();
-        await populateFilterTagButtons();
-        await populateTagDropdowns();
-    } catch (error) {
-        console.error("Error deleting tag:", error);
-        alert("Failed to delete tag.");
-    }
-}
-
-function openAddTagModalHandler() {
-    addTagPopup.style.display = 'block';
-    loadAndDisplayTagsForManagement();
-    newTagNameInput.focus();
-}
-
-function closeAddTagModalHandler() {
-    addTagPopup.style.display = 'none';
-    newTagNameInput.value = '';
-    existingTagsList.innerHTML = '';
-}
-
-// --- Dish Data Loading and Rendering ---
-
-function renderDishes(dishesToRender) {
-    if (!dishListContainer) return;
-    dishListContainer.innerHTML = '';
-
-    if (dishesToRender.length === 0) {
-        dishListContainer.innerHTML = '<p>No dishes found.</p>';
-        return;
-    }
-
-    dishesToRender.sort((a, b) => a.name.localeCompare(b.name));
-
-    dishesToRender.forEach(dish => {
-        const dishDiv = document.createElement('div');
-        dishDiv.classList.add('dish-item');
-        dishDiv.setAttribute('role', 'button');
-        dishDiv.setAttribute('tabindex', '0');
-
-        let displayTags = [];
-        if (Array.isArray(dish.tags)) {
-            displayTags = dish.tags
-                .filter(tag => tag)
-                .map(tag => capitalizeWords(tag));
-        }
-
-        const tagsHtml = displayTags.length > 0
-            ? `<p class="tags"><i class="fas fa-tags"></i> ${displayTags.join(', ')}</p>`
-            : '';
-
-        dishDiv.innerHTML = `
-            <h3>${capitalizeWords(dish.name)}</h3>
-            ${tagsHtml}
-        `;
-
-        const clickHandler = () => openEditModalHandler(dish.id, dish.name, dish.ingredients, dish.tags);
-        dishDiv.addEventListener('click', clickHandler);
-        dishDiv.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                clickHandler();
-            }
-        });
-
-        dishListContainer.appendChild(dishDiv);
-    });
-}
-
-function filterAndRenderDishes() {
-    let filteredDishes = [];
-    if (!currentFilterTag) {
-        filteredDishes = allLoadedDishes;
-    } else {
-        const lowerCaseFilter = currentFilterTag.toLowerCase();
-        filteredDishes = allLoadedDishes.filter(dish =>
-            Array.isArray(dish.tags) && dish.tags.some(tag => tag.toLowerCase() === lowerCaseFilter)
-        );
-    }
-    renderDishes(filteredDishes);
-}
-
-function applyFilterTag(tag) {
-    currentFilterTag = tag;
-    if (tagButtonsContainer) {
-        tagButtonsContainer.querySelectorAll('.tag-button').forEach(btn => {
-            const buttonTag = btn.dataset.tag || '';
-            if (buttonTag === currentFilterTag) {
-                btn.classList.add('active');
-            } else {
-                btn.classList.remove('active');
-            }
-        });
-    }
-    filterAndRenderDishes();
-    filterPopup.style.display = 'none';
-}
-
-// --- API Interactions (Dishes) ---
-
-async function fetchDishesFromAPI() {
-    console.log("Fetching latest dishes from API...");
-    if (!dishListContainer) return;
-
-    try {
-        const response = await fetch(`${API_URL}/dishes`);
-        if (!response.ok) throw new Error('Failed to fetch dishes');
-
-        allLoadedDishes = await response.json();
-
-        // Ensure data structure integrity
-        allLoadedDishes = allLoadedDishes.map(dish => ({
-            ...dish,
-            ingredients: dish.ingredients || {},
-            tags: dish.tags || []
-        }));
-
-        console.log("API fetch complete. Dishes loaded:", allLoadedDishes.length);
-
-        filterAndRenderDishes();
-        await populateFilterTagButtons();
-
-    } catch (error) {
-        console.error("Error loading dishes from API:", error);
-        if (dishListContainer) {
-            dishListContainer.innerHTML = '<p class="error-message">Could not load dishes. Please try again later.</p>';
-        }
-    }
-}
-
-async function saveDishToAPI() {
-    const dishName = newDishNameInput.value.trim();
-    if (!dishName) {
-        alert('Dish name cannot be empty.');
-        return;
-    }
-
-    addDishButton.disabled = true;
-    addDishButton.textContent = 'Saving...';
-
-    // Simplify structure: Ingredients will be stored as an object or array in the dish object itself
-    // For consistency with edit logic: use object where key is ID. But simplify to simple list?
-    // Let's stick to the current structure: ingredients is an object where keys are IDs.
-    // Since we are creating clean, let's auto-generate IDs for ingredients.
-    const ingredientsObj = {};
-    currentIngredients.forEach(ing => {
-        const id = `ing-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-        ingredientsObj[id] = {
-            name: ing.name.toLowerCase().trim(),
-            quantity: ing.quantity,
-            haveIt: false
-        };
-    });
-
-    const dishData = {
-        name: dishName,
-        tags: currentTags.map(tag => tag.toLowerCase()),
-        ingredients: ingredientsObj
-    };
-
-    try {
-        const response = await fetch(`${API_URL}/dishes`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(dishData)
-        });
-        if (!response.ok) throw new Error('Failed to save dish');
-
-        console.log("Dish added successfully");
-        closeAddDishModalHandler();
-        await fetchDishesFromAPI();
-
-    } catch (error) {
-        console.error("Error adding dish:", error);
-        alert('Failed to add dish. Please check your connection and try again.');
+        closeModal(els.dishModal);
+        await loadAll();
+    } catch (e) {
+        toast(e.message || 'Could not save dish', 'error');
     } finally {
-        addDishButton.disabled = false;
-        addDishButton.textContent = 'Save Dish';
+        els.saveDishBtn.disabled = false;
     }
 }
 
-async function saveEditedDish() {
-    const dishId = currentDishIdInput.value;
-    const updatedDishName = editDishNameInput.value.trim();
+async function deleteDish() {
+    if (!editingDish) return;
+    if (!confirm(`Delete "${capitalizeWords(editingDish.name)}"? This will also remove it from any planned meals.`)) return;
+    try {
+        await api.del(`/api/dishes/${editingDish.id}`);
+        toast('Dish deleted', 'info');
+        closeModal(els.dishModal);
+        await loadAll();
+    } catch (e) {
+        toast(e.message || 'Could not delete dish', 'error');
+    }
+}
 
-    if (!dishId || !updatedDishName) {
-        alert('Dish ID is missing or dish name cannot be empty.');
+function renderExistingTags() {
+    els.existingTagsList.innerHTML = '';
+    if (allTags.length === 0) {
+        const li = document.createElement('li');
+        li.style.background = 'transparent';
+        li.style.border = '0';
+        li.style.color = 'var(--text-muted)';
+        li.textContent = 'No tags yet — add some above';
+        els.existingTagsList.appendChild(li);
         return;
     }
-
-    saveEditedDishButton.disabled = true;
-    saveEditedDishButton.textContent = 'Saving...';
-
-    const updatedDishData = {
-        name: updatedDishName,
-        tags: editingTags.map(tag => tag.toLowerCase()),
-        ingredients: editingIngredients // This is already the object with updated details
-    };
-
-    try {
-        const response = await fetch(`${API_URL}/dishes/${dishId}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(updatedDishData)
-        });
-        if (!response.ok) throw new Error('Failed to update dish');
-
-        console.log("Dish updated:", dishId);
-        closeEditModalHandler();
-        await fetchDishesFromAPI();
-
-    } catch (error) {
-        console.error("Error updating dish:", error);
-        alert('Failed to update dish. Please check your connection and try again.');
-    } finally {
-        saveEditedDishButton.disabled = false;
-        saveEditedDishButton.textContent = 'Save Changes';
-    }
-}
-
-async function deleteDish(dishId) {
-    if (!dishId) {
-        console.error("deleteDish called with invalid dishId");
-        alert("Error: Dish ID is missing.");
-        return;
-    }
-
-    try {
-        const response = await fetch(`${API_URL}/dishes/${dishId}`, {
-            method: 'DELETE'
-        });
-        if (!response.ok) throw new Error('Failed to delete dish');
-
-        console.log(`Dish deleted: ${dishId}`);
-        // Optional: Trigger backend to cleanup meals using this dish, or handle locally?
-        // Current API `DELETE /meals/:date` is by date. We don't have a "delete by dish ID" call for meals yet.
-        // For now, meals might reference a deleted dish. We should probably update server.js to handle granular deletions if needed.
-        // Or simpler: Leave as is, user will resolve manually if they see a blank entry.
-
-        await fetchDishesFromAPI();
-
-        const editDishModal = document.getElementById('editDishModal');
-        if (editDishModal) editDishModal.style.display = 'none';
-
-    } catch (error) {
-        console.error("Error deleting dish:", error);
-        alert("An error occurred while deleting the dish. Please try again.");
-    }
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    const deleteEditedDishButton = document.getElementById('deleteEditedDishButton');
-
-    if (deleteEditedDishButton) {
-        deleteEditedDishButton.addEventListener('click', async () => {
-            const dishId = document.getElementById('currentDishId')?.value;
-            if (dishId) {
-                if (confirm('Are you sure you want to delete this dish and all associated history?')) {
-                    await deleteDish(dishId);
-                }
-            } else {
-                console.error("Dish ID not found in modal.");
+    allTags.forEach((t) => {
+        const li = document.createElement('li');
+        li.innerHTML = `<i class="fas fa-tag" style="font-size:0.7rem;"></i> ${escapeHtml(capitalizeWords(t.name))} <button class="remove" data-id="${t.id}" aria-label="Delete tag">&times;</button>`;
+        els.existingTagsList.appendChild(li);
+    });
+    els.existingTagsList.querySelectorAll('.remove').forEach((b) => {
+        b.addEventListener('click', async () => {
+            if (!confirm('Delete this tag? It will be removed from the available tag list (already-tagged dishes keep their tag text).')) return;
+            try {
+                await api.del(`/api/tags/${b.dataset.id}`);
+                toast('Tag deleted', 'info');
+                await loadAll();
+                renderExistingTags();
+            } catch (e) {
+                toast(e.message || 'Could not delete tag', 'error');
             }
         });
+    });
+}
+
+async function saveNewTag() {
+    const name = els.newTagName.value.trim().toLowerCase();
+    if (!name) return toast('Tag name required', 'error');
+    if (allTags.find((t) => t.name === name)) return toast('Tag already exists', 'info');
+    try {
+        await api.post('/api/tags', { name });
+        els.newTagName.value = '';
+        await loadAll();
+        renderExistingTags();
+        toast('Tag added', 'success');
+    } catch (e) {
+        toast(e.message || 'Could not add tag', 'error');
     }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const user = await requireUser();
+    if (!user) return;
+
+    renderHeader({ title: 'Dish Library', icon: 'fa-book', user });
+    renderBottomNav('dishes');
+
+    els.dishList = document.getElementById('dishList');
+    els.tagFilter = document.getElementById('tagFilterRow');
+    els.dishModal = document.getElementById('dishModal');
+    els.dishModalTitle = document.getElementById('dishModalTitle');
+    els.dishName = document.getElementById('dishName');
+    els.ingList = document.getElementById('ingredientList');
+    els.ingName = document.getElementById('ingName');
+    els.ingQty = document.getElementById('ingQty');
+    els.dishTagList = document.getElementById('dishTagList');
+    els.tagPicker = document.getElementById('tagPicker');
+    els.saveDishBtn = document.getElementById('saveDishBtn');
+    els.deleteDishBtn = document.getElementById('deleteDishBtn');
+    els.tagModal = document.getElementById('tagModal');
+    els.newTagName = document.getElementById('newTagName');
+    els.existingTagsList = document.getElementById('existingTagsList');
+
+    bindModalDismiss(els.dishModal, document.getElementById('closeDishModal'), document.getElementById('cancelDishBtn'));
+    bindModalDismiss(els.tagModal, document.getElementById('closeTagModal'));
+
+    document.getElementById('addDishBtn').addEventListener('click', () => openDishModal(null));
+    document.getElementById('manageTagsBtn').addEventListener('click', () => {
+        renderExistingTags();
+        openModal(els.tagModal);
+        setTimeout(() => els.newTagName.focus(), 80);
+    });
+    document.getElementById('saveTagBtn').addEventListener('click', saveNewTag);
+    els.newTagName.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); saveNewTag(); }
+    });
+
+    document.getElementById('addIngBtn').addEventListener('click', addIngredient);
+    [els.ingName, els.ingQty].forEach((inp) => inp.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); addIngredient(); }
+    }));
+    els.tagPicker.addEventListener('change', () => {
+        const v = els.tagPicker.value;
+        if (v && !workingTags.includes(v)) {
+            workingTags.push(v);
+            renderWorkingTags();
+            populateTagPicker();
+        }
+        els.tagPicker.value = '';
+    });
+    els.saveDishBtn.addEventListener('click', saveDish);
+    els.deleteDishBtn.addEventListener('click', deleteDish);
+
+    document.getElementById('dishSearch').addEventListener('input', (e) => {
+        searchQuery = e.target.value;
+        renderDishes();
+    });
+
+    await loadAll();
 });
-
-
-// --- Initialization ---
-
-function initializeAppAndListeners() {
-    console.log("Initializing App...");
-
-    // Initial Data Load
-    fetchDishesFromAPI();
-
-    // Event Listeners for UI
-    if (openAddDishModalButton) openAddDishModalButton.addEventListener('click', openAddDishModalHandler);
-    if (closeAddModalButton) closeAddModalButton.addEventListener('click', closeAddDishModalHandler);
-    if (closeEditModalButton) closeEditModalButton.addEventListener('click', closeEditModalHandler);
-    if (addDishButton) addDishButton.addEventListener('click', saveDishToAPI);
-    if (addDishWithIngredientsButton) addDishWithIngredientsButton.addEventListener('click', addIngredientToList);
-
-    if (newDishIngredientQuantityInput) {
-        newDishIngredientQuantityInput.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                addIngredientToList();
-            }
-        });
-    }
-    if (availableTagsAddDish) availableTagsAddDish.addEventListener('change', addTagToList);
-
-    if (saveEditedDishButton) saveEditedDishButton.addEventListener('click', saveEditedDish);
-    if (editAddIngredientButton) editAddIngredientButton.addEventListener('click', addOrUpdateEditIngredient);
-
-    if (editNewIngredientQuantityInput) {
-        editNewIngredientQuantityInput.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                addOrUpdateEditIngredient();
-            }
-        });
-    }
-    if (availableTagsEditDish) availableTagsEditDish.addEventListener('change', addEditTagToList);
-
-    if (openFilterPopupButton) {
-        openFilterPopupButton.addEventListener('click', (event) => {
-            event.stopPropagation();
-            filterPopup.style.display = filterPopup.style.display === 'flex' ? 'none' : 'flex';
-            if (filterPopup.style.display === 'flex') {
-                populateFilterTagButtons();
-            }
-        });
-    }
-    if (closeFilterPopupButton) {
-        closeFilterPopupButton.addEventListener('click', () => {
-            filterPopup.style.display = 'none';
-        });
-    }
-    if (clearFilterButton) clearFilterButton.addEventListener('click', () => applyFilterTag(''));
-
-    if (openAddTagPopupButton) openAddTagPopupButton.addEventListener('click', openAddTagModalHandler);
-    if (closeAddTagModalButton) closeAddTagModalButton.addEventListener('click', closeAddTagModalHandler);
-    if (saveNewTagButton) saveNewTagButton.addEventListener('click', saveTagToAPI);
-    if (newTagNameInput) {
-        newTagNameInput.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                saveTagToAPI();
-            }
-        });
-    }
-
-    window.addEventListener('click', (event) => {
-        if (event.target === addDishModal) closeAddDishModalHandler();
-        if (event.target === editDishModal) closeEditModalHandler();
-        if (event.target === addTagPopup) closeAddTagModalHandler();
-        if (filterPopup.style.display === 'flex' && !filterPopup.contains(event.target) && event.target !== openFilterPopupButton) {
-            filterPopup.style.display = 'none';
-        }
-    });
-
-}
-
-// --- Start ---
-initializeAppAndListeners();

--- a/family.html
+++ b/family.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Family · MealFinderrz</title>
+    <link rel="stylesheet" href="styles.css?v=20" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#072444" />
+    <link rel="icon" href="icon-180x180.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+          integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+    <header class="app-header"></header>
+
+    <main class="page">
+        <div id="content"></div>
+    </main>
+
+    <nav class="bottom-nav"></nav>
+
+    <script type="module">
+        import { api, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser } from './app.js?v=20';
+
+        function escapeHtml(s) {
+            return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+        }
+
+        let me;
+
+        async function load() {
+            const root = document.getElementById('content');
+            root.innerHTML = '<div class="skel" style="height: 220px;"></div>';
+            try {
+                const { family } = await api.get('/api/family');
+                if (!family) renderNoFamily(root);
+                else renderFamily(root, family);
+            } catch (e) {
+                root.innerHTML = `<div class="empty-state"><div class="icon"><i class="fas fa-triangle-exclamation"></i></div><h3>Could not load</h3><p>${escapeHtml(e.message)}</p></div>`;
+            }
+        }
+
+        function renderNoFamily(root) {
+            root.innerHTML = `
+                <div class="card">
+                    <h2 class="page-title"><i class="fas fa-people-roof" style="color: var(--brand-blue);"></i> You aren't in a family yet</h2>
+                    <p class="help">Create a new family to get a shared calendar &amp; dish library, or join one with an invite code.</p>
+
+                    <div class="auth-tabs" style="margin-top: 14px;" role="tablist">
+                        <button type="button" data-action="create" class="active">Create family</button>
+                        <button type="button" data-action="join">Join with code</button>
+                    </div>
+
+                    <div id="createBlock" style="margin-top: 14px;">
+                        <div class="field">
+                            <label for="newFamilyName">Family name</label>
+                            <input class="input" id="newFamilyName" placeholder="The Jacksons" maxlength="64" />
+                        </div>
+                        <button class="btn btn-block" id="createFamilyBtn" style="margin-top: 12px;">
+                            <i class="fas fa-house-chimney"></i> Create family
+                        </button>
+                    </div>
+
+                    <div id="joinBlock" style="display:none; margin-top: 14px;">
+                        <div class="field">
+                            <label for="joinCode">Invite code</label>
+                            <input class="input" id="joinCode" placeholder="ABC123" maxlength="6" style="text-transform: uppercase; letter-spacing: 4px; font-family: ui-monospace, monospace;" />
+                        </div>
+                        <button class="btn btn-block btn-yellow" id="joinFamilyBtn" style="margin-top: 12px;">
+                            <i class="fas fa-right-to-bracket"></i> Join family
+                        </button>
+                    </div>
+                </div>
+            `;
+
+            const tabs = root.querySelectorAll('.auth-tabs button');
+            const createBlock = root.querySelector('#createBlock');
+            const joinBlock = root.querySelector('#joinBlock');
+            tabs.forEach((b) => b.addEventListener('click', () => {
+                tabs.forEach((x) => x.classList.remove('active'));
+                b.classList.add('active');
+                const create = b.dataset.action === 'create';
+                createBlock.style.display = create ? '' : 'none';
+                joinBlock.style.display = create ? 'none' : '';
+            }));
+
+            root.querySelector('#createFamilyBtn').addEventListener('click', async () => {
+                const name = root.querySelector('#newFamilyName').value.trim();
+                try {
+                    await api.post('/api/family', { name });
+                    toast('Family created!', 'success');
+                    setTimeout(() => location.href = '/', 350);
+                } catch (e) {
+                    toast(e.message || 'Could not create family', 'error');
+                }
+            });
+            root.querySelector('#joinFamilyBtn').addEventListener('click', async () => {
+                const inviteCode = root.querySelector('#joinCode').value.trim().toUpperCase();
+                try {
+                    await api.post('/api/family/join', { inviteCode });
+                    toast('Joined family!', 'success');
+                    setTimeout(() => location.href = '/', 350);
+                } catch (e) {
+                    toast(e.message || 'Could not join', 'error');
+                }
+            });
+        }
+
+        function renderFamily(root, family) {
+            const isOwner = family.ownerId === me.id;
+            const initials = (n) => (n || '?').split(/\s+/).map((p) => p[0]).slice(0, 2).join('').toUpperCase();
+            const memberItems = family.members.map((m) => `
+                <li>
+                    <div class="avatar">${escapeHtml(initials(m.displayName))}</div>
+                    <div>
+                        <div class="name">${escapeHtml(m.displayName)} ${m.id === me.id ? '<span class="meta">· you</span>' : ''}</div>
+                        <div class="meta">@${escapeHtml(m.username)}</div>
+                    </div>
+                    ${m.id === family.ownerId ? '<span class="owner-tag">Owner</span>' : ''}
+                </li>
+            `).join('');
+
+            root.innerHTML = `
+                <div class="card family-card">
+                    <div style="display:flex; align-items:center; justify-content:space-between; gap:8px;">
+                        <h2 class="page-title" style="margin:0;"><i class="fas fa-people-roof" style="color: var(--brand-blue);"></i> ${escapeHtml(family.name)}</h2>
+                        ${isOwner ? '<button id="renameBtn" class="btn btn-ghost btn-sm"><i class="fas fa-pencil"></i> Rename</button>' : ''}
+                    </div>
+
+                    <div class="invite-row">
+                        <div>
+                            <div class="label">Invite code</div>
+                            <code>${escapeHtml(family.inviteCode)}</code>
+                        </div>
+                        <div style="display:flex; gap:6px;">
+                            <button class="btn btn-secondary btn-sm" id="copyCodeBtn"><i class="fas fa-copy"></i> Copy</button>
+                            ${isOwner ? '<button class="btn btn-ghost btn-sm" id="regenBtn" title="New code"><i class="fas fa-rotate"></i></button>' : ''}
+                        </div>
+                    </div>
+
+                    <div class="section-title">Members (${family.members.length})</div>
+                    <ul class="member-list">${memberItems}</ul>
+
+                    <div class="divider"></div>
+                    <div style="display:flex; flex-wrap:wrap; gap:8px; justify-content:flex-end;">
+                        <button class="btn btn-ghost" id="accountBtn"><i class="fas fa-user-gear"></i> Account</button>
+                        <button class="btn btn-danger" id="leaveBtn"><i class="fas fa-door-open"></i> Leave family</button>
+                    </div>
+                </div>
+
+                <div id="accountPanel" class="card" style="margin-top:14px; display:none;">
+                    <h2 class="page-title" style="margin-top:0;"><i class="fas fa-user-gear"></i> Account</h2>
+                    <div class="field">
+                        <label for="acctDisplayName">Display name</label>
+                        <input class="input" id="acctDisplayName" value="${escapeHtml(me.displayName)}" maxlength="64" />
+                    </div>
+                    <div class="section-title">Change password</div>
+                    <div class="field">
+                        <label for="acctCurrent">Current password</label>
+                        <input class="input" id="acctCurrent" type="password" autocomplete="current-password" />
+                    </div>
+                    <div class="field">
+                        <label for="acctNew">New password</label>
+                        <input class="input" id="acctNew" type="password" autocomplete="new-password" />
+                    </div>
+                    <button class="btn" id="saveAcctBtn" style="margin-top: 10px;"><i class="fas fa-check"></i> Save changes</button>
+                </div>
+            `;
+
+            root.querySelector('#copyCodeBtn').addEventListener('click', async () => {
+                try {
+                    await navigator.clipboard.writeText(family.inviteCode);
+                    toast('Invite code copied', 'success');
+                } catch {
+                    toast(family.inviteCode, 'info');
+                }
+            });
+
+            const regen = root.querySelector('#regenBtn');
+            if (regen) regen.addEventListener('click', async () => {
+                if (!confirm('Generate a new invite code? The old one will stop working.')) return;
+                try {
+                    const { inviteCode } = await api.post('/api/family/regenerate-code', {});
+                    toast(`New code: ${inviteCode}`, 'success', 4500);
+                    load();
+                } catch (e) {
+                    toast(e.message || 'Could not regenerate', 'error');
+                }
+            });
+
+            const rename = root.querySelector('#renameBtn');
+            if (rename) rename.addEventListener('click', async () => {
+                const name = prompt('New family name:', family.name);
+                if (!name || !name.trim()) return;
+                try {
+                    await api.put('/api/family', { name: name.trim() });
+                    toast('Family renamed', 'success');
+                    load();
+                } catch (e) {
+                    toast(e.message || 'Could not rename', 'error');
+                }
+            });
+
+            root.querySelector('#leaveBtn').addEventListener('click', async () => {
+                const msg = family.members.length === 1
+                    ? 'You are the only member. Leaving will permanently delete this family and all of its meals, dishes, and tags. Continue?'
+                    : 'Leave this family? You will lose access to its calendar and dish library (other members keep them).';
+                if (!confirm(msg)) return;
+                try {
+                    await api.post('/api/family/leave', {});
+                    toast('Left family', 'info');
+                    setTimeout(() => location.reload(), 350);
+                } catch (e) {
+                    toast(e.message || 'Could not leave', 'error');
+                }
+            });
+
+            const acctBtn = root.querySelector('#accountBtn');
+            const acctPanel = root.querySelector('#accountPanel');
+            acctBtn.addEventListener('click', () => {
+                acctPanel.style.display = acctPanel.style.display === 'none' ? '' : 'none';
+                if (acctPanel.style.display === '') acctPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+            root.querySelector('#saveAcctBtn').addEventListener('click', async () => {
+                const displayName = root.querySelector('#acctDisplayName').value.trim();
+                const currentPassword = root.querySelector('#acctCurrent').value;
+                const newPassword = root.querySelector('#acctNew').value;
+                const payload = { displayName };
+                if (newPassword) { payload.currentPassword = currentPassword; payload.newPassword = newPassword; }
+                try {
+                    const res = await api.put('/api/account', payload);
+                    me = res.user;
+                    toast('Saved', 'success');
+                    root.querySelector('#acctCurrent').value = '';
+                    root.querySelector('#acctNew').value = '';
+                    renderHeader({ title: 'Family', icon: 'fa-people-roof', user: me });
+                } catch (e) {
+                    toast(e.message || 'Could not save', 'error');
+                }
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            me = await requireUser();
+            if (!me) return;
+            renderHeader({ title: 'Family', icon: 'fa-people-roof', user: me });
+            renderBottomNav('home');
+            await load();
+        });
+    </script>
+</body>
+</html>

--- a/grocery.html
+++ b/grocery.html
@@ -1,53 +1,34 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Grocery List</title>
-    <link rel="stylesheet" href="styles.css?v=7">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Grocery List · MealFinderrz</title>
+    <link rel="stylesheet" href="styles.css?v=20" />
     <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#072444" />
+    <link rel="icon" href="icon-180x180.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-        integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
+          integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
+<body>
+    <header class="app-header"></header>
 
-<body class="grocery-page">
-    <header>
-        <h1><img src="launch.png" alt="Meals Icon">Grocery List</h1>
-        <a href="https://dunkin.fun" class="header-logo-link">
-            <img src="DunkinNet.png" alt="DunkinNet" class="header-logo">
-        </a>
-    </header>
-
-    <div class="grocery-list-actions">
-        <button id="clearGroceryList" class="clear-button">Clear All</button>
-    </div>
-
-    <div class="grocery-list-container">
-        <ul id="groceryList">
-        </ul>
-    </div>
-
-    <div class="bottom-navigation">
-        <div class="bottom-buttons">
-            <button id="dishLibraryButton" onclick="window.location.href='dishes.html'">
-                <i class="fas fa-book"></i>
+    <main class="page">
+        <div class="grocery-summary">
+            <div class="stats" id="groceryStats"></div>
+            <button id="clearGroceryList" class="btn btn-ghost btn-sm">
+                <i class="fas fa-rotate-left"></i> Reset all
             </button>
-            <button id="homeButton" onclick="window.location.href='index.html'">
-                <i class="fas fa-home"></i>
-            </button>
-            <div class="active-grocery-button">
-                <button id="active-groceryListButton">
-                    <i class="fas fa-list-check"></i>
-                </button>
-            </div>
         </div>
-    </div>
 
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.1.0-rc.0/js/select2.min.js"></script>
-    <script type="module" src="grocery.js"></script>
+        <div id="groceryListWrap"></div>
+    </main>
+
+    <nav class="bottom-nav"></nav>
+
+    <script type="module" src="grocery.js?v=20"></script>
 </body>
-
 </html>

--- a/grocery.js
+++ b/grocery.js
@@ -1,268 +1,188 @@
-const API_URL = '/api';
+import { api, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser } from './app.js?v=20';
 
-// DOM Elements
-const groceryListContainer = document.getElementById('groceryList');
-const clearGroceryListButton = document.getElementById('clearGroceryList');
+let groceryItems = []; // [{ name, totalQuantity, unit, haveIt, dishIds }]
+let allDishes = [];
 
+const els = {};
 
-// --- API Functions ---
-
-async function fetchMealsFromAPI(startDate) {
-    try {
-        const response = await fetch(`${API_URL}/meals`);
-        if (!response.ok) throw new Error('Failed to fetch meals');
-        const allMeals = await response.json(); // Object { "YYYY-MM-DD": "dishName" }
-
-        // Filter by date
-        const meals = [];
-        const start = new Date(startDate).getTime();
-
-        for (const [dateStr, dishName] of Object.entries(allMeals)) {
-            const mealDate = new Date(dateStr).getTime();
-            if (mealDate >= start) {
-                meals.push({
-                    date: dateStr,
-                    dishName: dishName
-                });
-            }
-        }
-        return meals;
-
-    } catch (error) {
-        console.error('Error fetching meals:', error);
-        return [];
-    }
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
-
-async function fetchDishesFromAPI() {
-    try {
-        const response = await fetch(`${API_URL}/dishes`);
-        if (!response.ok) throw new Error('Failed to fetch dishes');
-        return await response.json();
-    } catch (error) {
-        console.error('Error fetching dishes:', error);
-        return [];
-    }
-}
-
-async function updateDishInAPI(dishId, updatedData) {
-    try {
-        const response = await fetch(`${API_URL}/dishes/${dishId}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(updatedData)
-        });
-        if (!response.ok) throw new Error('Failed to update dish');
-    } catch (error) {
-        console.error(`Error updating dish ${dishId}:`, error);
-    }
-}
-
-async function getDishByName(dishName, allDishes) {
-    return allDishes.find(d => d.name === dishName);
-}
-
-
-// --- Grocery List Logic ---
 
 function pluralizeUnit(unit, quantity) {
-    if (quantity > 1 && unit) {
-        if (unit.toLowerCase() === 'box') {
-            return 'Boxes';
-        } else if (unit.toLowerCase().endsWith('s')) {
-            return unit;
-        } else {
-            return unit + 's';
-        }
-    }
-    return unit;
+    if (!unit) return '';
+    if (quantity <= 1) return unit;
+    const u = unit.toLowerCase();
+    if (u === 'box') return 'Boxes';
+    if (u.endsWith('s')) return unit;
+    return unit + 's';
 }
 
-let groceryListCache = []; // Store the generated grocery list
+async function buildList() {
+    els.wrap.innerHTML = `
+        <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
+        <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
+        <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
+    `;
+    try {
+        const [meals, dishes] = await Promise.all([
+            api.get('/api/meals').catch(() => ({})),
+            api.get('/api/dishes').catch(() => []),
+        ]);
+        allDishes = dishes;
 
-function displayGroceryList(groceryList) {
-    groceryListContainer.innerHTML = '';
+        const today = new Date();
+        const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
 
-    if (groceryList.length === 0) {
-        const noMealsMessage = document.createElement('li');
-        noMealsMessage.textContent = 'No ingredients needed.';
-        groceryListContainer.appendChild(noMealsMessage);
-    } else {
-        groceryList.forEach(item => {
-            const listItem = document.createElement('li');
+        const dishesByName = new Map(dishes.map((d) => [d.name, d]));
+        const acc = {};
 
-            const checkbox = document.createElement('input');
-            checkbox.type = 'checkbox';
-            checkbox.classList.add('grocery-item-checkbox');
-            checkbox.dataset.ingredientName = item.name;
-            checkbox.dataset.dishIds = JSON.stringify(item.dishIds);
-            checkbox.checked = item.haveIt || false;
-
-            checkbox.addEventListener('change', async (event) => {
-                const ingredientName = event.target.dataset.ingredientName;
-                const dishIds = JSON.parse(event.target.dataset.dishIds);
-                const isChecked = event.target.checked;
-
-                // Update Local Cache
-                const updatedList = groceryListCache.map(cachedItem => {
-                    if (cachedItem.name === ingredientName) {
-                        return { ...cachedItem, haveIt: isChecked };
-                    }
-                    return cachedItem;
-                });
-                groceryListCache = updatedList;
-                displayGroceryList(groceryListCache);
-
-                // Update API (Backend)
-                // We need to update the 'haveIt' status for this ingredient in ALL dishes that have it.
-                // This requires fetching the specific dishes, updating the specific ingredient in their ingredients object, and saving back.
-                // Optimally we'd have an API endpoint to 'toggle ingredient haveIt', but let's do it client-side logic for now.
-
-                // Fetch all dishes first to be efficient? No, iterate dishIds.
-                const allDishes = await fetchDishesFromAPI(); // Get fresh data
-
-                for (const dishId of dishIds) {
-                    const dish = allDishes.find(d => d.id === dishId);
-                    if (dish && dish.ingredients) {
-                        // find ingredient entry. Ingredients is an object { id: {name, ...} }
-                        let modified = false;
-                        for (const [key, val] of Object.entries(dish.ingredients)) {
-                            if (val.name.toLowerCase() === ingredientName.toLowerCase()) {
-                                dish.ingredients[key].haveIt = isChecked;
-                                modified = true;
-                            }
-                        }
-                        if (modified) {
-                            await updateDishInAPI(dish.id, dish);
-                        }
-                    }
+        for (const [dateStr, dishName] of Object.entries(meals)) {
+            const t = new Date(dateStr).getTime();
+            if (isNaN(t) || t < startOfToday) continue;
+            const dish = dishesByName.get(dishName);
+            if (!dish || !dish.ingredients) continue;
+            for (const ing of Object.values(dish.ingredients)) {
+                const cleanName = (ing.name || '').toLowerCase().trim();
+                if (!cleanName) continue;
+                const q = (ing.quantity || '').toString();
+                const qtyMatch = q.match(/[\d.]+/);
+                const unitMatch = q.match(/[a-zA-Z]+/);
+                const qty = qtyMatch ? parseFloat(qtyMatch[0]) : 1;
+                const unit = unitMatch ? unitMatch[0] : '';
+                if (!acc[cleanName]) {
+                    acc[cleanName] = {
+                        name: cleanName,
+                        totalQuantity: 0,
+                        unit: '',
+                        haveIt: false,
+                        dishIds: [],
+                    };
                 }
-            });
-
-            const capitalizedIngredientName = item.name.split(' ').map(word => {
-                return word.charAt(0).toUpperCase() + word.slice(1);
-            }).join(' ');
-
-            let displayText = capitalizedIngredientName;
-            let quantityAndUnit = '';
-            if (item.totalQuantity > 0) {
-                quantityAndUnit += ` (x ${item.totalQuantity}`;
-                if (item.unit) {
-                    const pluralUnit = pluralizeUnit(item.unit, item.totalQuantity);
-                    quantityAndUnit += ` ${pluralUnit})`;
-                } else {
-                    quantityAndUnit += `)`;
-                }
+                acc[cleanName].totalQuantity += isNaN(qty) ? 0 : qty;
+                if (unit && !acc[cleanName].unit) acc[cleanName].unit = unit;
+                acc[cleanName].haveIt = acc[cleanName].haveIt || !!ing.haveIt;
+                if (!acc[cleanName].dishIds.includes(dish.id)) acc[cleanName].dishIds.push(dish.id);
             }
+        }
 
-            const textSpan = document.createElement('span');
-            textSpan.textContent = displayText + quantityAndUnit;
-
-            listItem.appendChild(textSpan);
-            listItem.appendChild(checkbox);
-            groceryListContainer.appendChild(listItem);
+        groceryItems = Object.values(acc).sort((a, b) => {
+            // Unchecked first, then alpha
+            if (a.haveIt !== b.haveIt) return a.haveIt ? 1 : -1;
+            return a.name.localeCompare(b.name);
         });
+        render();
+    } catch (e) {
+        els.wrap.innerHTML = `<div class="empty-state"><div class="icon"><i class="fas fa-triangle-exclamation"></i></div><h3>Could not load list</h3><p>${escapeHtml(e.message)}</p></div>`;
     }
 }
 
-async function generateGroceryList() {
-    // Current logic: Fetch all meals from today onwards.
-    const today = new Date();
-    const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-    const startDateStr = startOfToday.toISOString().split('T')[0]; // simple comparison string? No, API returns whatever cache matches. logic uses timestamps.
+function render() {
+    const total = groceryItems.length;
+    const got = groceryItems.filter((i) => i.haveIt).length;
+    els.stats.textContent = total === 0 ? 'No ingredients needed' : `${got} of ${total} got it`;
+
+    if (total === 0) {
+        els.wrap.innerHTML = `
+            <div class="empty-state">
+                <div class="icon"><i class="fas fa-basket-shopping"></i></div>
+                <h3>Nothing to buy</h3>
+                <p>Plan some meals on the calendar — ingredients will show up here.</p>
+                <a href="/" class="btn"><i class="fas fa-calendar-days"></i> Open calendar</a>
+            </div>
+        `;
+        return;
+    }
+
+    const ul = document.createElement('ul');
+    ul.className = 'grocery-list';
+    groceryItems.forEach((item, idx) => {
+        const li = document.createElement('li');
+        if (item.haveIt) li.classList.add('checked');
+        const qtyText = item.totalQuantity > 0
+            ? `${item.totalQuantity}${item.unit ? ' ' + pluralizeUnit(item.unit, item.totalQuantity) : ''}`
+            : '';
+        li.innerHTML = `
+            <input type="checkbox" class="grocery-checkbox" ${item.haveIt ? 'checked' : ''} aria-label="Got ${escapeHtml(item.name)}" />
+            <span class="name">${escapeHtml(capitalizeWords(item.name))}</span>
+            ${qtyText ? `<span class="qty">${escapeHtml(qtyText)}</span>` : ''}
+        `;
+        const cb = li.querySelector('input');
+        const toggle = async () => {
+            cb.checked = !cb.checked;
+            await onToggle(idx, cb.checked);
+        };
+        li.addEventListener('click', (e) => {
+            if (e.target === cb) return;
+            toggle();
+        });
+        cb.addEventListener('click', (e) => e.stopPropagation());
+        cb.addEventListener('change', () => onToggle(idx, cb.checked));
+        ul.appendChild(li);
+    });
+    els.wrap.innerHTML = '';
+    els.wrap.appendChild(ul);
+}
+
+async function onToggle(idx, checked) {
+    const item = groceryItems[idx];
+    item.haveIt = checked;
+
+    // Optimistic re-sort + render
+    groceryItems.sort((a, b) => {
+        if (a.haveIt !== b.haveIt) return a.haveIt ? 1 : -1;
+        return a.name.localeCompare(b.name);
+    });
+    render();
 
     try {
-        const meals = await fetchMealsFromAPI(startDateStr);
-        if (meals.length === 0) {
-            groceryListContainer.innerHTML = '<li>No meals planned for today or later.</li>';
-            return;
-        }
-
-        const allDishes = await fetchDishesFromAPI();
-        const ingredientQuantities = {};
-
-        for (const meal of meals) {
-            const dish = await getDishByName(meal.dishName, allDishes);
-            if (dish && dish.ingredients) {
-                // Iterate over ingredients object
-                Object.values(dish.ingredients).forEach(ingredient => {
-                    const cleanIngredientName = ingredient.name.toLowerCase().trim();
-                    const quantityWithUnit = ingredient.quantity || '';
-                    const unitMatch = quantityWithUnit.match(/[a-zA-Z]+/);
-                    const quantityMatch = quantityWithUnit.match(/[\d.]+/);
-                    const quantity = quantityMatch ? parseFloat(quantityMatch[0]) : 1;
-                    const unit = unitMatch ? unitMatch[0].trim() : '';
-                    const haveIt = ingredient.haveIt || false;
-
-                    if (ingredientQuantities[cleanIngredientName]) {
-                        ingredientQuantities[cleanIngredientName].totalQuantity += quantity;
-                        // Unit merging logic (kept simple)
-                        if (unit && ingredientQuantities[cleanIngredientName].unit === '') {
-                            ingredientQuantities[cleanIngredientName].unit = unit;
-                        }
-                        // Consolidate 'haveIt'. If it's true in one, is it true in all? 
-                        // Logic says: if you have it for one dish, you usually have it for all unless you used it up.
-                        // But UI shows a global checkbox. Let's sync it.
-                        ingredientQuantities[cleanIngredientName].haveIt = ingredientQuantities[cleanIngredientName].haveIt || haveIt;
-
-                        if (!ingredientQuantities[cleanIngredientName].dishIds.includes(dish.id)) {
-                            ingredientQuantities[cleanIngredientName].dishIds.push(dish.id);
-                        }
-                    } else {
-                        ingredientQuantities[cleanIngredientName] = {
-                            name: cleanIngredientName,
-                            totalQuantity: quantity,
-                            unit: unit,
-                            haveIt: haveIt,
-                            dishIds: [dish.id]
-                        };
-                    }
-                });
+        // Persist by updating each affected dish's ingredient.haveIt
+        for (const dishId of item.dishIds) {
+            const dish = allDishes.find((d) => d.id === dishId);
+            if (!dish || !dish.ingredients) continue;
+            let modified = false;
+            for (const [key, val] of Object.entries(dish.ingredients)) {
+                if ((val.name || '').toLowerCase() === item.name.toLowerCase() && val.haveIt !== checked) {
+                    dish.ingredients[key].haveIt = checked;
+                    modified = true;
+                }
             }
+            if (modified) await api.put(`/api/dishes/${dish.id}`, dish);
         }
-
-        const groceryList = Object.values(ingredientQuantities).sort((a, b) => a.name.localeCompare(b.name));
-        groceryListCache = groceryList;
-        displayGroceryList(groceryList);
-
-    } catch (error) {
-        console.error("Error generating grocery list:", error);
-        groceryListContainer.innerHTML = '<li>Error loading grocery list.</li>';
+    } catch (e) {
+        toast(e.message || 'Could not save change', 'error');
     }
 }
 
-async function clearAllGroceryList() {
-    if (!confirm("Reset 'Have It' status for all ingredients?")) return;
-
+async function clearAll() {
+    if (!confirm("Reset 'Got it' status for every ingredient?")) return;
     try {
-        const allDishes = await fetchDishesFromAPI();
         for (const dish of allDishes) {
             let modified = false;
             if (dish.ingredients) {
-                for (const key in dish.ingredients) {
-                    if (dish.ingredients[key].haveIt) {
-                        dish.ingredients[key].haveIt = false;
+                for (const k in dish.ingredients) {
+                    if (dish.ingredients[k].haveIt) {
+                        dish.ingredients[k].haveIt = false;
                         modified = true;
                     }
                 }
             }
-            if (modified) {
-                await updateDishInAPI(dish.id, dish);
-            }
+            if (modified) await api.put(`/api/dishes/${dish.id}`, dish);
         }
-        await generateGroceryList(); // Refresh
-    } catch (error) {
-        console.error("Error clearing grocery list:", error);
+        toast('List reset', 'info');
+        await buildList();
+    } catch (e) {
+        toast(e.message || 'Could not reset', 'error');
     }
 }
 
-// --- Initialization ---
-
-if (clearGroceryListButton) {
-    clearGroceryListButton.addEventListener('click', clearAllGroceryList);
-}
-
-// Initial load
-document.addEventListener('DOMContentLoaded', () => {
-    generateGroceryList();
+document.addEventListener('DOMContentLoaded', async () => {
+    const user = await requireUser();
+    if (!user) return;
+    renderHeader({ title: 'Grocery List', icon: 'fa-list-check', user });
+    renderBottomNav('grocery');
+    els.wrap = document.getElementById('groceryListWrap');
+    els.stats = document.getElementById('groceryStats');
+    document.getElementById('clearGroceryList').addEventListener('click', clearAll);
+    await buildList();
 });

--- a/index.html
+++ b/index.html
@@ -1,80 +1,63 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Meal Planner</title>
-    <link rel="stylesheet" href="styles.css?v=7">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Calendar · MealFinderrz</title>
+    <link rel="stylesheet" href="styles.css?v=20" />
     <link rel="manifest" href="manifest.json" />
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="icon" href="icon-180x180.png">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="#072444" />
+    <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-startup-image" href="launch.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.1.0-rc.0/css/select2.min.css" rel="stylesheet" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-        integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
-
+          integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
-
 <body>
-    <header>
-        <h1><img src="launch.png" alt="Meals Icon">Meal Planner</h1>
-        <a href="https://dunkin.fun" class="header-logo-link">
-            <img src="DunkinNet.png" alt="DunkinNet" class="header-logo">
-        </a>
-    </header>
+    <header class="app-header"></header>
 
-    <div class="calendar-container">
-        <div class="calendar-header">
-            <button id="prevMonth">&lt;</button>
-            <h2 id="currentMonth"></h2>
-            <button id="nextMonth">&gt;</button>
-        </div>
-        <div class="calendar-weekdays">
-            <div>S</div>
-            <div>M</div>
-            <div>T</div>
-            <div>W</div>
-            <div>T</div>
-            <div>F</div>
-            <div>S</div>
-        </div>
-        <div class="calendar-grid" id="calendarGrid">
-        </div>
-    </div>
-
-    <div class="add-meal-modal" id="addMealModal">
-        <div class="modal-content">
-            <span class="close-button" id="closeModal">&times;</span>
-            <h3><span id="modalDate"></span></h3>
-            <button id="randomMealButton" class="random-meal-button">
-                <i class="fas fa-dice"></i> I'm Feeling Hungry
-            </button>
-            <select id="selectDish">
-            </select>
-        </div>
-    </div>
-    <div class="bottom-navigation">
-        <div class="bottom-buttons">
-            <button id="dishLibraryButton" onclick="window.location.href='dishes.html'">
-                <i class="fas fa-book"></i>
-            </button>
-            <div class="active-home-button">
-                <button id="active-homeButton">
-                    <i class="fas fa-home"></i>
+    <main class="page">
+        <section class="calendar-card">
+            <div class="calendar-toolbar">
+                <button id="prevMonth" class="calendar-nav-btn" aria-label="Previous month"><i class="fas fa-chevron-left"></i></button>
+                <h2 id="currentMonth"></h2>
+                <button id="nextMonth" class="calendar-nav-btn" aria-label="Next month"><i class="fas fa-chevron-right"></i></button>
             </div>
-            </button>
-            <button id="groceryListButton" onclick="window.location.href='grocery.html'">
-                <i class="fas fa-list-check"></i>
-            </button>
+            <div style="display:flex; justify-content:flex-end; margin-bottom:8px;">
+                <button id="todayBtn" class="today-btn">Today</button>
+            </div>
+            <div class="calendar-weekdays" aria-hidden="true">
+                <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>
+            </div>
+            <div class="calendar-grid" id="calendarGrid"></div>
+        </section>
+    </main>
+
+    <div class="modal" id="addMealModal" role="dialog" aria-modal="true" aria-labelledby="modalDate">
+        <div class="sheet">
+            <div class="sheet-grabber" aria-hidden="true"></div>
+            <div class="sheet-header">
+                <h3 id="modalDate"></h3>
+                <button class="sheet-close" id="closeModal" aria-label="Close">&times;</button>
+            </div>
+            <div class="sheet-body">
+                <button id="randomMealButton" class="random-btn">
+                    <i class="fas fa-dice"></i> Surprise me
+                </button>
+                <input class="dish-search-input" id="dishSearch" type="text" placeholder="Search for a dish…" />
+                <ul class="dish-pick-list" id="dishPickList"></ul>
+                <div class="clear-meal-row">
+                    <span class="help" id="currentMealLabel"></span>
+                    <button class="btn btn-ghost btn-sm" id="clearMealBtn"><i class="fas fa-trash-can"></i> Clear meal</button>
+                </div>
+            </div>
         </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.1.0-rc.0/js/select2.min.js"></script>
-    <script type="module" src="script.js?v=2"></script>
-</body>
+    <nav class="bottom-nav"></nav>
 
+    <script type="module" src="script.js?v=20"></script>
+</body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Sign in · MealFinderrz</title>
+    <link rel="stylesheet" href="styles.css?v=20" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="icon-180x180.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+          integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="auth-page">
+    <div class="auth-card">
+        <div class="auth-brand">
+            <div class="brand-icon"><i class="fas fa-utensils"></i></div>
+            <div>
+                <h1>MealFinderrz</h1>
+                <p class="subtitle">Plan tonight's dinner together.</p>
+            </div>
+        </div>
+
+        <form id="loginForm" class="field" autocomplete="on">
+            <div class="field">
+                <label for="username">Username</label>
+                <input class="input" type="text" id="username" name="username" required autofocus autocomplete="username" />
+            </div>
+            <div class="field">
+                <label for="password">Password</label>
+                <input class="input" type="password" id="password" name="password" required autocomplete="current-password" />
+            </div>
+            <button class="btn btn-block btn-lg" type="submit" id="submitBtn">
+                <i class="fas fa-arrow-right-to-bracket"></i> Sign in
+            </button>
+        </form>
+
+        <p class="auth-footer">
+            New here? <a href="/register">Create an account</a>
+        </p>
+    </div>
+
+    <script type="module">
+        import { api, toast } from './app.js?v=20';
+
+        // If already signed in, bounce to home
+        api.get('/api/auth/me').then(({ user }) => {
+            if (user) location.href = user.familyId ? '/' : '/family';
+        }).catch(() => {});
+
+        const form = document.getElementById('loginForm');
+        const submitBtn = document.getElementById('submitBtn');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const username = document.getElementById('username').value.trim();
+            const password = document.getElementById('password').value;
+            submitBtn.disabled = true;
+            const original = submitBtn.innerHTML;
+            submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Signing in…';
+            try {
+                const { user } = await api.post('/api/auth/login', { username, password });
+                toast(`Welcome back, ${user.displayName}!`, 'success');
+                setTimeout(() => { location.href = user.familyId ? '/' : '/family'; }, 350);
+            } catch (err) {
+                toast(err.message || 'Login failed', 'error');
+                submitBtn.disabled = false;
+                submitBtn.innerHTML = original;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,14 @@
 {
-  "name": "Dinner Planner",
+  "name": "MealFinderrz",
   "short_name": "Meals",
-  "start_url": ".",
+  "description": "Family meal planner — shared calendar, dish library, and grocery list.",
+  "start_url": "/",
   "display": "standalone",
   "background_color": "#072444",
   "theme_color": "#072444",
+  "orientation": "portrait",
   "icons": [
-    {
-      "src": "launch.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
+    { "src": "icon-180x180.png", "type": "image/png", "sizes": "180x180" },
+    { "src": "launch.png", "type": "image/png", "sizes": "512x512", "purpose": "any maskable" }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,729 +1,17 @@
 {
   "name": "mealfinderrz",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mealfinderrz",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "cookie-session": "^2.1.0",
         "cors": "^2.8.5",
-        "express": "^4.18.2",
-        "firebase": "^11.0.2",
-        "node-fetch": "^3.3.2"
-      }
-    },
-    "node_modules/@firebase/ai": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.1.tgz",
-      "integrity": "sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x",
-        "@firebase/app-types": "0.x"
-      }
-    },
-    "node_modules/@firebase/analytics": {
-      "version": "0.10.17",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.17.tgz",
-      "integrity": "sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.23.tgz",
-      "integrity": "sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/analytics": "0.10.17",
-        "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/analytics-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
-      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
-      "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/app-check": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.10.1.tgz",
-      "integrity": "sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.26.tgz",
-      "integrity": "sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check": "0.10.1",
-        "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-check-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
-      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-compat": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
-      "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app": "0.13.2",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.8.tgz",
-      "integrity": "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^1.18.1"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-async-storage/async-storage": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@firebase/auth-compat": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.28.tgz",
-      "integrity": "sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/auth": "1.10.8",
-        "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth-types": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
-      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
-    },
-    "node_modules/@firebase/component": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
-      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/data-connect": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.10.tgz",
-      "integrity": "sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/database": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.20.tgz",
-      "integrity": "sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "faye-websocket": "0.11.4",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/database-compat": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.11.tgz",
-      "integrity": "sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/database": "1.0.20",
-        "@firebase/database-types": "1.0.15",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/database-types": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.15.tgz",
-      "integrity": "sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.12.1"
-      }
-    },
-    "node_modules/@firebase/firestore": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.8.0.tgz",
-      "integrity": "sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "@firebase/webchannel-wrapper": "1.0.3",
-        "@grpc/grpc-js": "~1.9.0",
-        "@grpc/proto-loader": "^0.7.8",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.53",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.53.tgz",
-      "integrity": "sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/firestore": "4.8.0",
-        "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/firestore-types": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
-      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
-    },
-    "node_modules/@firebase/functions": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.9.tgz",
-      "integrity": "sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/functions-compat": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.26.tgz",
-      "integrity": "sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/functions": "0.12.9",
-        "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/functions-types": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
-      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/installations": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.18.tgz",
-      "integrity": "sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/installations-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.18.tgz",
-      "integrity": "sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/installations-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
-      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x"
-      }
-    },
-    "node_modules/@firebase/logger": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
-      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/messaging": {
-      "version": "0.12.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.22.tgz",
-      "integrity": "sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.12.1",
-        "idb": "7.1.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.22.tgz",
-      "integrity": "sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/messaging": "0.12.22",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
-      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/performance": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.7.tgz",
-      "integrity": "sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0",
-        "web-vitals": "^4.2.4"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/performance-compat": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.20.tgz",
-      "integrity": "sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/performance": "0.7.7",
-        "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/performance-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
-      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/remote-config": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.5.tgz",
-      "integrity": "sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.18.tgz",
-      "integrity": "sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/remote-config": "0.6.5",
-        "@firebase/remote-config-types": "0.4.0",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/remote-config-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
-      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/storage": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.14.tgz",
-      "integrity": "sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x"
-      }
-    },
-    "node_modules/@firebase/storage-compat": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.24.tgz",
-      "integrity": "sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/storage": "0.13.14",
-        "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.12.1",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/storage-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
-      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
-    },
-    "node_modules/@firebase/util": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
-      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
-      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@grpc/grpc-js": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
-      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
+        "express": "^4.18.2"
       }
     },
     "node_modules/accepts": {
@@ -739,40 +27,22 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -783,7 +53,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -791,6 +61,36 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bytes": {
@@ -831,38 +131,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -893,16 +161,44 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-session": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.1.1.tgz",
+      "integrity": "sha512-ji3kym/XZaFVew1+tIZk5ZLp9Z/fLv9rK1aZmpug0FsgE7Cu3ZDrUdRo7FT9vFjMYfNimrrUHJzywDwT7XEFlg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookies": "0.9.1",
+        "debug": "3.2.7",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -910,24 +206,19 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "node_modules/depd": {
@@ -969,12 +260,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1012,15 +297,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1084,40 +360,20 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/faye-websocket": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
+        "ms": "2.0.0"
       }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -1137,53 +393,20 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/firebase": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.10.0.tgz",
-      "integrity": "sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/ai": "1.4.1",
-        "@firebase/analytics": "0.10.17",
-        "@firebase/analytics-compat": "0.2.23",
-        "@firebase/app": "0.13.2",
-        "@firebase/app-check": "0.10.1",
-        "@firebase/app-check-compat": "0.3.26",
-        "@firebase/app-compat": "0.4.2",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.10.8",
-        "@firebase/auth-compat": "0.5.28",
-        "@firebase/data-connect": "0.3.10",
-        "@firebase/database": "1.0.20",
-        "@firebase/database-compat": "2.0.11",
-        "@firebase/firestore": "4.8.0",
-        "@firebase/firestore-compat": "0.3.53",
-        "@firebase/functions": "0.12.9",
-        "@firebase/functions-compat": "0.3.26",
-        "@firebase/installations": "0.6.18",
-        "@firebase/installations-compat": "0.2.18",
-        "@firebase/messaging": "0.12.22",
-        "@firebase/messaging-compat": "0.2.22",
-        "@firebase/performance": "0.7.7",
-        "@firebase/performance-compat": "0.2.20",
-        "@firebase/remote-config": "0.6.5",
-        "@firebase/remote-config-compat": "0.2.18",
-        "@firebase/storage": "0.13.14",
-        "@firebase/storage-compat": "0.3.24",
-        "@firebase/util": "1.12.1"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
+        "ms": "2.0.0"
       }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -1210,15 +433,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1283,9 +497,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1314,12 +528,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-parser-js": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-      "license": "MIT"
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1331,12 +539,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/idb": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
-      "license": "ISC"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1353,26 +555,17 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
       "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.6"
       }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1444,9 +637,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1456,44 +649,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -1529,6 +684,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1539,34 +703,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
-    },
-    "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1582,9 +722,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1618,15 +758,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1679,10 +810,19 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/serve-static": {
@@ -1726,13 +866,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1787,32 +927,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1822,11 +936,14 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1840,12 +957,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1872,97 +983,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-parser-js": ">=0.5.1",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/websocket-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "mealfinderrz",
-  "version": "1.0.0",
-  "description": "Meal finder app migrated to local storage",
+  "version": "2.0.0",
+  "description": "Family meal planner with shared calendars, dish library, and grocery lists",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "dev": "node server.js"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-session": "^2.1.0",
     "cors": "^2.8.5",
     "express": "^4.18.2"
   }

--- a/register.html
+++ b/register.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Create account · MealFinderrz</title>
+    <link rel="stylesheet" href="styles.css?v=20" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="icon-180x180.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+          integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="auth-page">
+    <div class="auth-card">
+        <div class="auth-brand">
+            <div class="brand-icon"><i class="fas fa-utensils"></i></div>
+            <div>
+                <h1>Create account</h1>
+                <p class="subtitle">Plan meals with your household.</p>
+            </div>
+        </div>
+
+        <form id="registerForm" class="field">
+            <div class="field">
+                <label for="displayName">Your name</label>
+                <input class="input" type="text" id="displayName" placeholder="Robert" required maxlength="64" />
+            </div>
+            <div class="field">
+                <label for="username">Username</label>
+                <input class="input" type="text" id="username" required minlength="3" maxlength="32" autocomplete="username"
+                       pattern="[A-Za-z0-9_.\-]+" placeholder="rob" />
+                <span class="help">Letters, numbers, dot, underscore, dash. 3–32 characters.</span>
+            </div>
+            <div class="field">
+                <label for="password">Password</label>
+                <input class="input" type="password" id="password" required minlength="6" autocomplete="new-password" />
+                <span class="help">At least 6 characters.</span>
+            </div>
+
+            <div class="divider"></div>
+
+            <div class="auth-tabs" role="tablist">
+                <button type="button" data-action="create" class="active">Create family</button>
+                <button type="button" data-action="join">Join with code</button>
+            </div>
+
+            <div class="field" id="familyNameField">
+                <label for="familyName">Family name</label>
+                <input class="input" type="text" id="familyName" placeholder="The Jacksons" maxlength="64" />
+                <span class="help">You can change this later. You'll get an invite code to share.</span>
+            </div>
+
+            <div class="field" id="inviteCodeField" style="display: none;">
+                <label for="inviteCode">Invite code</label>
+                <input class="input" type="text" id="inviteCode" placeholder="ABC123" maxlength="6" style="text-transform: uppercase; letter-spacing: 4px; font-family: ui-monospace, monospace;" />
+                <span class="help">Ask your family member for the 6-character code.</span>
+            </div>
+
+            <button class="btn btn-block btn-lg" type="submit" id="submitBtn">
+                <i class="fas fa-user-plus"></i> Create account
+            </button>
+        </form>
+
+        <p class="auth-footer">
+            Already have an account? <a href="/login">Sign in</a>
+        </p>
+    </div>
+
+    <script type="module">
+        import { api, toast } from './app.js?v=20';
+
+        api.get('/api/auth/me').then(({ user }) => {
+            if (user) location.href = user.familyId ? '/' : '/family';
+        }).catch(() => {});
+
+        let familyAction = 'create';
+        const tabs = document.querySelectorAll('.auth-tabs button');
+        const familyNameField = document.getElementById('familyNameField');
+        const inviteCodeField = document.getElementById('inviteCodeField');
+
+        tabs.forEach((btn) => {
+            btn.addEventListener('click', () => {
+                tabs.forEach((b) => b.classList.remove('active'));
+                btn.classList.add('active');
+                familyAction = btn.dataset.action;
+                familyNameField.style.display = familyAction === 'create' ? '' : 'none';
+                inviteCodeField.style.display = familyAction === 'join' ? '' : 'none';
+            });
+        });
+
+        const form = document.getElementById('registerForm');
+        const submitBtn = document.getElementById('submitBtn');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const payload = {
+                displayName: document.getElementById('displayName').value.trim(),
+                username: document.getElementById('username').value.trim(),
+                password: document.getElementById('password').value,
+                familyAction,
+                familyName: document.getElementById('familyName').value.trim(),
+                inviteCode: document.getElementById('inviteCode').value.trim(),
+            };
+            submitBtn.disabled = true;
+            const original = submitBtn.innerHTML;
+            submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Creating…';
+            try {
+                const { user } = await api.post('/api/auth/register', payload);
+                toast(`Welcome, ${user.displayName}!`, 'success');
+                setTimeout(() => { location.href = user.familyId ? '/' : '/family'; }, 400);
+            } catch (err) {
+                toast(err.message || 'Could not create account', 'error');
+                submitBtn.disabled = false;
+                submitBtn.innerHTML = original;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,324 +1,213 @@
-// Global variables
+import { api, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser } from './app.js?v=20';
+
 let currentDate = new Date();
-let meals = {}; // In-memory cache for meals
-const API_URL = '/api'; // Relative URL since served by the same server
+let meals = {};
+let dishes = [];
+let activeDateKey = null;
 
-// DOM Elements (initialized in DOMContentLoaded)
-let prevMonthButton;
-let nextMonthButton;
-let currentMonthDisplay;
-let calendarGrid;
-let addMealModal;
-let closeModalButton;
-let modalDateDisplay;
-let selectDishDropdown; // This will be the jQuery Select2 element
-let groceryListButton;
-let dishLibraryButton;
-let randomMealButton;
+const els = {};
 
-// --- API Meal Functions ---
+function fmtDateKey(d) {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
 
-async function loadMealsFromAPI() {
-    meals = {}; // Clear local cache
+function formatDateLong(dateKey) {
+    const [y, m, d] = dateKey.split('-').map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+        weekday: 'long', month: 'long', day: 'numeric',
+    });
+}
+
+async function loadMeals() {
     try {
-        const response = await fetch(`${API_URL}/meals`);
-        if (!response.ok) throw new Error('Failed to fetch meals');
-        meals = await response.json();
-        console.log('Meals loaded from API:', meals);
-        renderCalendar();
-    } catch (error) {
-        console.error('Error loading meals from API:', error);
+        meals = (await api.get('/api/meals')) || {};
+    } catch {
+        meals = {};
     }
 }
 
-async function loadDishesAndPopulateDropdown() {
-    if (!selectDishDropdown) {
-        console.error("Select dish dropdown element not found.");
-        return;
-    }
+async function loadDishes() {
     try {
-        const response = await fetch(`${API_URL}/dishes`);
-        if (!response.ok) throw new Error('Failed to fetch dishes');
-        const dishes = await response.json();
-
-        // Format data for Select2
-        const select2Data = dishes.map(dish => ({
-            id: dish.name, // Use dish name as ID for simplicity in calendar mapping
-            text: dish.name
-        }));
-
-        // Clear existing options
-        $(selectDishDropdown).empty();
-        $(selectDishDropdown).append('<option value="">Select a dish</option>'); // Default placeholder
-        $(selectDishDropdown).append('<option value="clear-meal">Clear Meal</option>'); // Option to clear
-
-        // Initialize Select2 with the data
-        $(selectDishDropdown).select2({
-            placeholder: 'Search or select a dish',
-            allowClear: true,
-            dropdownParent: $('#addMealModal'),
-            data: select2Data
-        });
-
-        // Attach the change event listener *once* after initialization
-        $(selectDishDropdown).off('change', handleMealSelectionChange).on('change', handleMealSelectionChange);
-
-        console.log('Dishes loaded and dropdown populated using Select2 data.');
-
-    } catch (error) {
-        console.error("Error loading dishes:", error);
+        dishes = (await api.get('/api/dishes')) || [];
+        dishes.sort((a, b) => a.name.localeCompare(b.name));
+    } catch {
+        dishes = [];
     }
 }
-
-async function saveOrUpdateMealInAPI(dateKey, dishName) {
-    try {
-        const response = await fetch(`${API_URL}/meals`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ date: dateKey, dishName: dishName })
-        });
-        if (!response.ok) throw new Error('Failed to save meal');
-
-        meals[dateKey] = dishName;
-        console.log(`Meal saved to API for date: ${dateKey}, dish: ${dishName}`);
-    } catch (error) {
-        console.error('Error saving/updating meal in API:', error);
-    }
-}
-
-async function clearMealFromAPI(dateKey) {
-    try {
-        const response = await fetch(`${API_URL}/meals/${dateKey}`, {
-            method: 'DELETE'
-        });
-        if (!response.ok) throw new Error('Failed to delete meal');
-
-        console.log(`Meal cleared from API for date: ${dateKey}`);
-        delete meals[dateKey];
-    } catch (error) {
-        console.error('Error clearing meal from API:', error);
-    }
-}
-
-
-// --- Calendar Rendering ---
 
 function renderCalendar() {
-    if (!calendarGrid || !currentMonthDisplay) {
-        console.error("Calendar elements not ready for rendering.");
-        return;
-    }
-
     const year = currentDate.getFullYear();
-    const month = currentDate.getMonth(); // 0-indexed
-    const firstDayOfMonth = new Date(year, month, 1);
-    const lastDayOfMonth = new Date(year, month + 1, 0);
-    const daysInMonth = lastDayOfMonth.getDate();
-    const startingDay = firstDayOfMonth.getDay(); // Sunday - Saturday : 0 - 6
+    const month = currentDate.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    const daysInMonth = lastDay.getDate();
+    const startingDay = firstDay.getDay();
 
-    currentMonthDisplay.textContent = firstDayOfMonth.toLocaleDateString('en-US', {
-        year: 'numeric', month: 'long'
+    els.currentMonth.textContent = firstDay.toLocaleDateString('en-US', {
+        year: 'numeric', month: 'long',
     });
-    calendarGrid.innerHTML = ''; // Clear previous grid
 
-    // Add empty cells for padding days
+    els.grid.innerHTML = '';
+    const today = new Date();
+    const todayKey = fmtDateKey(today);
+
     for (let i = 0; i < startingDay; i++) {
-        const emptyCell = document.createElement('div');
-        calendarGrid.appendChild(emptyCell);
+        const cell = document.createElement('div');
+        cell.className = 'day empty';
+        els.grid.appendChild(cell);
     }
 
-    // Add day cells
-    for (let day = 1; day <= daysInMonth; day++) {
-        const dayCell = document.createElement('div');
-        dayCell.classList.add('day');
-        dayCell.textContent = day;
+    for (let d = 1; d <= daysInMonth; d++) {
+        const cell = document.createElement('button');
+        cell.type = 'button';
+        cell.className = 'day';
+        const dateKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+        if (dateKey === todayKey) cell.classList.add('today');
+        if (meals[dateKey]) cell.classList.add('has-meal');
 
-        // Format dateKey consistently as YYYY-MM-DD
-        const dateKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+        const num = document.createElement('span');
+        num.className = 'day-num';
+        num.textContent = d;
+        cell.appendChild(num);
 
-        const today = new Date();
-        const isToday = today.getFullYear() === year && today.getMonth() === month && today.getDate() === day;
-        if (isToday) {
-            dayCell.classList.add('today');
-        }
-
-        // Check if a meal exists for this date in the local 'meals' cache
         if (meals[dateKey]) {
-            dayCell.classList.add('has-meal');
-            const mealDisplay = document.createElement('div');
-            mealDisplay.classList.add('day-content');
-            mealDisplay.textContent = meals[dateKey];
-            dayCell.appendChild(mealDisplay);
+            const meal = document.createElement('span');
+            meal.className = 'meal';
+            meal.textContent = meals[dateKey];
+            cell.appendChild(meal);
         }
 
-        // Add click listener to open the modal
-        dayCell.addEventListener('click', () => openAddMealModal(dateKey));
-        calendarGrid.appendChild(dayCell);
+        cell.addEventListener('click', () => openMealModal(dateKey));
+        els.grid.appendChild(cell);
     }
 }
 
-// --- Modal Interaction ---
+function renderDishPickList(query = '') {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+        ? dishes.filter((d) => d.name.toLowerCase().includes(q) || (d.tags || []).some((t) => t.toLowerCase().includes(q)))
+        : dishes;
+    const current = activeDateKey ? meals[activeDateKey] : null;
 
-function openAddMealModal(dateKey) {
-    if (!addMealModal || !modalDateDisplay || !selectDishDropdown) {
-        console.error("Modal elements not found.");
+    els.pickList.innerHTML = '';
+    if (filtered.length === 0) {
+        const li = document.createElement('li');
+        li.className = 'empty';
+        li.textContent = q ? `No dishes match "${query}"` : 'No dishes saved yet. Add some in the Dish Library!';
+        els.pickList.appendChild(li);
         return;
     }
-
-    modalDateDisplay.textContent = formatDateForDisplay(dateKey);
-    addMealModal.dataset.selectedDate = dateKey;
-
-    const selectDish = $(selectDishDropdown);
-
-    // Initialize Select2 if needed (it should be initialized by loadDishesAndPopulateDropdown already)
-    // Just ensuring it's ready and updating value
-
-    // Set value based on existing meal for this date, or null if none
-    const existingMeal = meals[dateKey] || null;
-    selectDish.val(existingMeal).trigger('change.select2');
-
-    addMealModal.style.display = 'flex';
-    selectDish.select2('open');
-}
-
-async function handleMealSelectionChange() {
-    const selectedDish = $(this).val();
-    const selectedDate = addMealModal.dataset.selectedDate;
-
-    if (!selectedDate) {
-        console.error("Selected date is missing from modal data.");
-        return;
-    }
-
-    console.log(`Date: ${selectedDate}, Dish selected: ${selectedDish}`);
-
-    try {
-        if (selectedDish === 'clear-meal') {
-            await clearMealFromAPI(selectedDate);
-        } else if (selectedDish) {
-            await saveOrUpdateMealInAPI(selectedDate, selectedDish);
-        } else {
-            console.log("Dish selection cleared.");
-        }
-
-        renderCalendar();
-        addMealModal.style.display = 'none';
-        $(this).val(null).trigger('change.select2');
-
-    } catch (error) {
-        console.error("Error handling meal selection change:", error);
-        alert("An error occurred while updating the meal. Please try again.");
-    }
-}
-
-
-// --- Random Meal Selection ---
-
-async function selectRandomMeal(event) {
-    // Prevent event from bubbling up and closing modal prematurely
-    if (event) {
-        event.preventDefault();
-        event.stopPropagation();
-    }
-
-    // Close the Select2 dropdown first
-    $(selectDishDropdown).select2('close');
-
-    const selectedDate = addMealModal.dataset.selectedDate;
-    if (!selectedDate) {
-        console.error("No date selected for random meal.");
-        return;
-    }
-
-    try {
-        // Fetch all dishes from the API
-        const response = await fetch(`${API_URL}/dishes`);
-        if (!response.ok) throw new Error('Failed to fetch dishes');
-        const dishes = await response.json();
-
-        if (!dishes || dishes.length === 0) {
-            alert('No saved dishes available. Please add some dishes first!');
-            return;
-        }
-
-        // Pick a random dish
-        const randomIndex = Math.floor(Math.random() * dishes.length);
-        const randomDish = dishes[randomIndex];
-
-        // Save the random dish to the selected date
-        await saveOrUpdateMealInAPI(selectedDate, randomDish.name);
-
-        // Refresh calendar first, then close modal
-        renderCalendar();
-        addMealModal.style.display = 'none';
-
-        console.log(`Random meal selected: ${randomDish.name} for ${selectedDate}`);
-    } catch (error) {
-        console.error('Error selecting random meal:', error);
-        alert('An error occurred while selecting a random meal. Please try again.');
-    }
-}
-
-// --- Utility Functions ---
-
-function formatDateForDisplay(dateKey) {
-    const [year, month, day] = dateKey.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-    return date.toLocaleDateString('en-US', {
-        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
+    filtered.forEach((dish) => {
+        const li = document.createElement('li');
+        if (dish.name === current) li.classList.add('selected');
+        const tagText = (dish.tags || []).slice(0, 2).map(capitalizeWords).join(' · ');
+        li.innerHTML = `
+            <div style="flex:1; min-width:0;">
+                <div style="font-weight:600;">${escapeHtml(capitalizeWords(dish.name))}</div>
+                ${tagText ? `<div style="font-size:0.78rem; color: var(--text-muted);">${escapeHtml(tagText)}</div>` : ''}
+            </div>
+        `;
+        li.addEventListener('click', () => pickDish(dish.name));
+        els.pickList.appendChild(li);
     });
 }
 
-// --- Initialization ---
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+async function pickDish(name) {
+    if (!activeDateKey) return;
+    try {
+        await api.post('/api/meals', { date: activeDateKey, dishName: name });
+        meals[activeDateKey] = name;
+        renderCalendar();
+        closeModal(els.modal);
+        toast(`Saved ${capitalizeWords(name)} for ${formatDateLong(activeDateKey)}`, 'success');
+    } catch (e) {
+        toast(e.message || 'Could not save meal', 'error');
+    }
+}
+
+async function clearMeal() {
+    if (!activeDateKey) return;
+    if (!meals[activeDateKey]) {
+        closeModal(els.modal);
+        return;
+    }
+    try {
+        await api.del(`/api/meals/${activeDateKey}`);
+        delete meals[activeDateKey];
+        renderCalendar();
+        closeModal(els.modal);
+        toast('Meal cleared', 'info');
+    } catch (e) {
+        toast(e.message || 'Could not clear meal', 'error');
+    }
+}
+
+async function pickRandom() {
+    if (!dishes.length) {
+        toast('Add some dishes first in the Dish Library!', 'info');
+        return;
+    }
+    const random = dishes[Math.floor(Math.random() * dishes.length)];
+    await pickDish(random.name);
+}
+
+function openMealModal(dateKey) {
+    activeDateKey = dateKey;
+    els.modalDate.textContent = formatDateLong(dateKey);
+    els.search.value = '';
+    const current = meals[dateKey];
+    els.currentMealLabel.textContent = current ? `Currently: ${capitalizeWords(current)}` : 'No meal planned';
+    renderDishPickList('');
+    openModal(els.modal);
+    setTimeout(() => els.search.focus(), 80);
+}
 
 document.addEventListener('DOMContentLoaded', async () => {
-    // Get DOM Elements
-    prevMonthButton = document.getElementById('prevMonth');
-    nextMonthButton = document.getElementById('nextMonth');
-    currentMonthDisplay = document.getElementById('currentMonth');
-    calendarGrid = document.getElementById('calendarGrid');
-    addMealModal = document.getElementById('addMealModal');
-    closeModalButton = document.getElementById('closeModal');
-    modalDateDisplay = document.getElementById('modalDate');
-    selectDishDropdown = document.getElementById('selectDish');
-    groceryListButton = document.getElementById('groceryListButton');
-    dishLibraryButton = document.getElementById('dishLibraryButton');
-    randomMealButton = document.getElementById('randomMealButton');
+    const user = await requireUser();
+    if (!user) return;
 
-    // Load initial data
-    await loadDishesAndPopulateDropdown();
-    await loadMealsFromAPI();
+    renderHeader({ title: 'Meal Planner', icon: 'fa-calendar-days', user });
+    renderBottomNav('home');
 
-    // Event Listeners
-    if (prevMonthButton) {
-        prevMonthButton.addEventListener('click', () => {
-            currentDate.setMonth(currentDate.getMonth() - 1);
-            renderCalendar();
-        });
-    }
+    els.currentMonth = document.getElementById('currentMonth');
+    els.grid = document.getElementById('calendarGrid');
+    els.modal = document.getElementById('addMealModal');
+    els.modalDate = document.getElementById('modalDate');
+    els.search = document.getElementById('dishSearch');
+    els.pickList = document.getElementById('dishPickList');
+    els.currentMealLabel = document.getElementById('currentMealLabel');
 
-    if (nextMonthButton) {
-        nextMonthButton.addEventListener('click', () => {
-            currentDate.setMonth(currentDate.getMonth() + 1);
-            renderCalendar();
-        });
-    }
+    bindModalDismiss(els.modal, document.getElementById('closeModal'));
 
-    if (closeModalButton) {
-        closeModalButton.addEventListener('click', () => {
-            if (addMealModal) addMealModal.style.display = 'none';
-        });
-    }
+    document.getElementById('prevMonth').addEventListener('click', () => {
+        currentDate.setMonth(currentDate.getMonth() - 1);
+        renderCalendar();
+    });
+    document.getElementById('nextMonth').addEventListener('click', () => {
+        currentDate.setMonth(currentDate.getMonth() + 1);
+        renderCalendar();
+    });
+    document.getElementById('todayBtn').addEventListener('click', () => {
+        currentDate = new Date();
+        renderCalendar();
+    });
+    document.getElementById('randomMealButton').addEventListener('click', pickRandom);
+    document.getElementById('clearMealBtn').addEventListener('click', clearMeal);
+    els.search.addEventListener('input', (e) => renderDishPickList(e.target.value));
+    els.search.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            const first = els.pickList.querySelector('li:not(.empty)');
+            if (first) first.click();
+        }
+    });
 
-    if (addMealModal) {
-        window.addEventListener('click', (event) => {
-            if (event.target === addMealModal) {
-                addMealModal.style.display = 'none';
-            }
-        });
-    }
-
-    if (randomMealButton) {
-        randomMealButton.addEventListener('click', selectRandomMeal);
-    }
+    await Promise.all([loadMeals(), loadDishes()]);
+    renderCalendar();
 });

--- a/server.js
+++ b/server.js
@@ -1,66 +1,439 @@
 const express = require('express');
 const cors = require('cors');
+const cookieSession = require('cookie-session');
+const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
 const fs = require('fs/promises');
+const fssync = require('fs');
 const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 const DATA_DIR = path.join(__dirname, 'data');
 const DB_FILE = path.join(DATA_DIR, 'db.json');
+const SESSION_KEY =
+    process.env.SESSION_SECRET ||
+    (() => {
+        const keyPath = path.join(DATA_DIR, '.session-key');
+        try {
+            if (fssync.existsSync(keyPath)) {
+                return fssync.readFileSync(keyPath, 'utf8');
+            }
+        } catch {}
+        const k = crypto.randomBytes(32).toString('hex');
+        try {
+            fssync.mkdirSync(DATA_DIR, { recursive: true });
+            fssync.writeFileSync(keyPath, k, { mode: 0o600 });
+        } catch (e) {
+            console.warn('Could not persist session key, sessions will reset on restart:', e.message);
+        }
+        return k;
+    })();
 
-app.use(cors());
-app.use(express.json());
-app.use(express.static(__dirname)); // Serve static files (frontend)
+app.set('trust proxy', 1);
+app.use(cors({ origin: true, credentials: true }));
+app.use(express.json({ limit: '1mb' }));
+app.use(
+    cookieSession({
+        name: 'mfsession',
+        keys: [SESSION_KEY],
+        maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+        sameSite: 'lax',
+        httpOnly: true,
+        secure: false, // behind reverse proxy that terminates TLS
+    })
+);
 
-// Ensure data directory and file exist
+// ─── DB Helpers ──────────────────────────────────────────────────────────────
+
+const EMPTY_FAMILY_DATA = () => ({ meals: {}, dishes: [], tags: [] });
+
+const EMPTY_DB = () => ({
+    version: 2,
+    users: [],
+    families: [],
+    familyData: {},
+});
+
+let writeQueue = Promise.resolve();
+
 async function initDB() {
+    await fs.mkdir(DATA_DIR, { recursive: true });
+    let db;
     try {
-        await fs.access(DATA_DIR);
+        const raw = await fs.readFile(DB_FILE, 'utf8');
+        db = JSON.parse(raw);
     } catch {
-        await fs.mkdir(DATA_DIR);
+        db = EMPTY_DB();
+        await fs.writeFile(DB_FILE, JSON.stringify(db, null, 2));
+        return;
     }
-    try {
-        await fs.access(DB_FILE);
-    } catch {
-        const initialData = { meals: {}, dishes: [], tags: [] };
-        await fs.writeFile(DB_FILE, JSON.stringify(initialData, null, 2));
+
+    // Migrate legacy v1 (flat meals/dishes/tags) to v2
+    if (!db.version || db.version < 2) {
+        const legacyMeals = db.meals || {};
+        const legacyDishes = db.dishes || [];
+        const legacyTags = db.tags || [];
+        const familyId = 'family-legacy';
+        const family = {
+            id: familyId,
+            name: 'My Family',
+            inviteCode: generateInviteCode(),
+            createdAt: new Date().toISOString(),
+            ownerId: null,
+        };
+        const migrated = EMPTY_DB();
+        migrated.families = [family];
+        migrated.familyData[familyId] = {
+            meals: legacyMeals,
+            dishes: legacyDishes,
+            tags: legacyTags,
+        };
+        await fs.writeFile(DB_FILE, JSON.stringify(migrated, null, 2));
+        console.log('[migration] Legacy v1 data migrated into family:', familyId);
     }
 }
 
 async function readDB() {
-    const data = await fs.readFile(DB_FILE, 'utf8');
-    return JSON.parse(data);
+    const raw = await fs.readFile(DB_FILE, 'utf8');
+    return JSON.parse(raw);
 }
 
-async function writeDB(data) {
-    await fs.writeFile(DB_FILE, JSON.stringify(data, null, 2));
+function writeDB(data) {
+    writeQueue = writeQueue
+        .catch(() => {})
+        .then(async () => {
+            const tmp = DB_FILE + '.tmp';
+            await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+            await fs.rename(tmp, DB_FILE);
+        });
+    return writeQueue;
 }
 
-// --- API Endpoints ---
+function generateId(prefix = 'id') {
+    return `${prefix}-${Date.now().toString(36)}-${crypto.randomBytes(4).toString('hex')}`;
+}
 
-// Get all meals
-app.get('/api/meals', async (req, res) => {
+function generateInviteCode() {
+    const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let code = '';
+    for (let i = 0; i < 6; i++) {
+        code += alphabet[crypto.randomInt(0, alphabet.length)];
+    }
+    return code;
+}
+
+function ensureFamilyData(db, familyId) {
+    if (!db.familyData[familyId]) {
+        db.familyData[familyId] = EMPTY_FAMILY_DATA();
+    }
+    return db.familyData[familyId];
+}
+
+function publicUser(u) {
+    if (!u) return null;
+    return {
+        id: u.id,
+        username: u.username,
+        displayName: u.displayName,
+        familyId: u.familyId,
+        createdAt: u.createdAt,
+    };
+}
+
+function publicFamily(f, members = []) {
+    if (!f) return null;
+    return {
+        id: f.id,
+        name: f.name,
+        inviteCode: f.inviteCode,
+        createdAt: f.createdAt,
+        ownerId: f.ownerId,
+        members: members.map(publicUser),
+    };
+}
+
+// ─── Auth Middleware ─────────────────────────────────────────────────────────
+
+async function loadUser(req, res, next) {
+    if (!req.session || !req.session.userId) {
+        req.user = null;
+        return next();
+    }
     try {
         const db = await readDB();
-        // Convert object to array for frontend if needed, or keep as object
-        // The frontend expects some format, let's stick to what we have in the DB for now: an object or array?
-        // In the original code, `meals` was an object keyed by date.
-        // Let's return the whole object map.
-        res.json(db.meals || {});
+        const user = db.users.find((u) => u.id === req.session.userId);
+        req.user = user || null;
+        if (!user) req.session = null;
+    } catch (e) {
+        req.user = null;
+    }
+    next();
+}
+
+function requireAuth(req, res, next) {
+    if (!req.user) return res.status(401).json({ error: 'Not authenticated' });
+    next();
+}
+
+function requireFamily(req, res, next) {
+    if (!req.user) return res.status(401).json({ error: 'Not authenticated' });
+    if (!req.user.familyId) return res.status(403).json({ error: 'No family. Create or join one.' });
+    next();
+}
+
+app.use(loadUser);
+
+// ─── Auth Routes ─────────────────────────────────────────────────────────────
+
+app.post('/api/auth/register', async (req, res) => {
+    try {
+        const { username, password, displayName, familyAction, familyName, inviteCode } = req.body || {};
+        if (!username || !password) return res.status(400).json({ error: 'Username and password are required' });
+        if (username.length < 3 || username.length > 32)
+            return res.status(400).json({ error: 'Username must be 3–32 characters' });
+        if (!/^[a-zA-Z0-9_.-]+$/.test(username))
+            return res.status(400).json({ error: 'Username may only contain letters, numbers, ., _ and -' });
+        if (password.length < 6) return res.status(400).json({ error: 'Password must be at least 6 characters' });
+
+        const db = await readDB();
+        const normalized = username.toLowerCase();
+        if (db.users.some((u) => u.username.toLowerCase() === normalized))
+            return res.status(409).json({ error: 'Username already taken' });
+
+        // Resolve family
+        let familyId = null;
+        let familyToCreate = null;
+        if (familyAction === 'join') {
+            const code = (inviteCode || '').trim().toUpperCase();
+            if (!code) return res.status(400).json({ error: 'Invite code required to join a family' });
+            const family = db.families.find((f) => (f.inviteCode || '').toUpperCase() === code);
+            if (!family) return res.status(404).json({ error: 'No family found with that invite code' });
+            familyId = family.id;
+        } else if (familyAction === 'create' || !familyAction) {
+            const name = (familyName || `${displayName || username}'s Family`).trim().slice(0, 64);
+            familyToCreate = {
+                id: generateId('fam'),
+                name: name || 'My Family',
+                inviteCode: generateInviteCode(),
+                createdAt: new Date().toISOString(),
+                ownerId: null,
+            };
+            familyId = familyToCreate.id;
+        } else if (familyAction === 'none') {
+            familyId = null;
+        }
+
+        const passwordHash = await bcrypt.hash(password, 10);
+        const user = {
+            id: generateId('usr'),
+            username,
+            passwordHash,
+            displayName: (displayName || username).slice(0, 64),
+            familyId,
+            createdAt: new Date().toISOString(),
+        };
+        if (familyToCreate) {
+            familyToCreate.ownerId = user.id;
+            db.families.push(familyToCreate);
+            ensureFamilyData(db, familyToCreate.id);
+        } else if (familyId) {
+            // If joining a legacy family without owner, claim it
+            const f = db.families.find((x) => x.id === familyId);
+            if (f && !f.ownerId) f.ownerId = user.id;
+            ensureFamilyData(db, familyId);
+        }
+        db.users.push(user);
+        await writeDB(db);
+
+        req.session.userId = user.id;
+        res.json({ user: publicUser(user) });
+    } catch (error) {
+        console.error('register error:', error);
+        res.status(500).json({ error: 'Registration failed' });
+    }
+});
+
+app.post('/api/auth/login', async (req, res) => {
+    try {
+        const { username, password } = req.body || {};
+        if (!username || !password) return res.status(400).json({ error: 'Username and password are required' });
+        const db = await readDB();
+        const user = db.users.find((u) => u.username.toLowerCase() === username.toLowerCase());
+        if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+        const ok = await bcrypt.compare(password, user.passwordHash);
+        if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
+        req.session.userId = user.id;
+        res.json({ user: publicUser(user) });
+    } catch (error) {
+        console.error('login error:', error);
+        res.status(500).json({ error: 'Login failed' });
+    }
+});
+
+app.post('/api/auth/logout', (req, res) => {
+    req.session = null;
+    res.json({ success: true });
+});
+
+app.get('/api/auth/me', (req, res) => {
+    res.json({ user: publicUser(req.user) });
+});
+
+// ─── Family Routes ───────────────────────────────────────────────────────────
+
+app.get('/api/family', requireAuth, async (req, res) => {
+    const db = await readDB();
+    if (!req.user.familyId) return res.json({ family: null });
+    const family = db.families.find((f) => f.id === req.user.familyId);
+    const members = db.users.filter((u) => u.familyId === req.user.familyId);
+    res.json({ family: publicFamily(family, members) });
+});
+
+app.post('/api/family', requireAuth, async (req, res) => {
+    try {
+        const { name } = req.body || {};
+        const db = await readDB();
+        const fresh = db.users.find((u) => u.id === req.user.id);
+        if (fresh.familyId) return res.status(400).json({ error: 'You already belong to a family. Leave it first.' });
+        const family = {
+            id: generateId('fam'),
+            name: (name || `${fresh.displayName}'s Family`).trim().slice(0, 64),
+            inviteCode: generateInviteCode(),
+            createdAt: new Date().toISOString(),
+            ownerId: fresh.id,
+        };
+        db.families.push(family);
+        ensureFamilyData(db, family.id);
+        fresh.familyId = family.id;
+        await writeDB(db);
+        const members = db.users.filter((u) => u.familyId === family.id);
+        res.json({ family: publicFamily(family, members) });
+    } catch (e) {
+        console.error('create family:', e);
+        res.status(500).json({ error: 'Could not create family' });
+    }
+});
+
+app.post('/api/family/join', requireAuth, async (req, res) => {
+    try {
+        const code = ((req.body && req.body.inviteCode) || '').trim().toUpperCase();
+        if (!code) return res.status(400).json({ error: 'Invite code required' });
+        const db = await readDB();
+        const family = db.families.find((f) => (f.inviteCode || '').toUpperCase() === code);
+        if (!family) return res.status(404).json({ error: 'No family found with that invite code' });
+        const fresh = db.users.find((u) => u.id === req.user.id);
+        if (fresh.familyId === family.id) return res.json({ family: publicFamily(family) });
+        if (fresh.familyId) return res.status(400).json({ error: 'Leave your current family before joining another' });
+        fresh.familyId = family.id;
+        if (!family.ownerId) family.ownerId = fresh.id;
+        ensureFamilyData(db, family.id);
+        await writeDB(db);
+        const members = db.users.filter((u) => u.familyId === family.id);
+        res.json({ family: publicFamily(family, members) });
+    } catch (e) {
+        console.error('join family:', e);
+        res.status(500).json({ error: 'Could not join family' });
+    }
+});
+
+app.post('/api/family/leave', requireAuth, async (req, res) => {
+    try {
+        const db = await readDB();
+        const fresh = db.users.find((u) => u.id === req.user.id);
+        if (!fresh.familyId) return res.json({ success: true });
+        const familyId = fresh.familyId;
+        fresh.familyId = null;
+        // If this was the owner, transfer to another member, or delete family + data if empty
+        const family = db.families.find((f) => f.id === familyId);
+        const remaining = db.users.filter((u) => u.familyId === familyId);
+        if (family) {
+            if (remaining.length === 0) {
+                db.families = db.families.filter((f) => f.id !== familyId);
+                delete db.familyData[familyId];
+            } else if (family.ownerId === fresh.id) {
+                family.ownerId = remaining[0].id;
+            }
+        }
+        await writeDB(db);
+        res.json({ success: true });
+    } catch (e) {
+        console.error('leave family:', e);
+        res.status(500).json({ error: 'Could not leave family' });
+    }
+});
+
+app.post('/api/family/regenerate-code', requireAuth, async (req, res) => {
+    try {
+        const db = await readDB();
+        const family = db.families.find((f) => f.id === req.user.familyId);
+        if (!family) return res.status(404).json({ error: 'Family not found' });
+        if (family.ownerId !== req.user.id) return res.status(403).json({ error: 'Only the family owner can do that' });
+        family.inviteCode = generateInviteCode();
+        await writeDB(db);
+        res.json({ inviteCode: family.inviteCode });
+    } catch (e) {
+        res.status(500).json({ error: 'Could not regenerate code' });
+    }
+});
+
+app.put('/api/family', requireAuth, async (req, res) => {
+    try {
+        const { name } = req.body || {};
+        const db = await readDB();
+        const family = db.families.find((f) => f.id === req.user.familyId);
+        if (!family) return res.status(404).json({ error: 'Family not found' });
+        if (family.ownerId !== req.user.id) return res.status(403).json({ error: 'Only the family owner can rename' });
+        family.name = (name || family.name).trim().slice(0, 64) || family.name;
+        await writeDB(db);
+        res.json({ family: publicFamily(family) });
+    } catch (e) {
+        res.status(500).json({ error: 'Could not update family' });
+    }
+});
+
+app.put('/api/account', requireAuth, async (req, res) => {
+    try {
+        const { displayName, currentPassword, newPassword } = req.body || {};
+        const db = await readDB();
+        const u = db.users.find((x) => x.id === req.user.id);
+        if (!u) return res.status(404).json({ error: 'User not found' });
+        if (typeof displayName === 'string' && displayName.trim()) {
+            u.displayName = displayName.trim().slice(0, 64);
+        }
+        if (newPassword) {
+            if (!currentPassword) return res.status(400).json({ error: 'Current password required to change password' });
+            const ok = await bcrypt.compare(currentPassword, u.passwordHash);
+            if (!ok) return res.status(401).json({ error: 'Current password is incorrect' });
+            if (newPassword.length < 6) return res.status(400).json({ error: 'New password must be at least 6 characters' });
+            u.passwordHash = await bcrypt.hash(newPassword, 10);
+        }
+        await writeDB(db);
+        res.json({ user: publicUser(u) });
+    } catch (e) {
+        res.status(500).json({ error: 'Could not update account' });
+    }
+});
+
+// ─── Meal Routes (family-scoped) ─────────────────────────────────────────────
+
+app.get('/api/meals', requireFamily, async (req, res) => {
+    try {
+        const db = await readDB();
+        const data = ensureFamilyData(db, req.user.familyId);
+        res.json(data.meals || {});
     } catch (error) {
         res.status(500).json({ error: error.message });
     }
 });
 
-// Save or Update a meal
-app.post('/api/meals', async (req, res) => {
+app.post('/api/meals', requireFamily, async (req, res) => {
     try {
-        const { date, dishName } = req.body;
+        const { date, dishName } = req.body || {};
         if (!date || !dishName) return res.status(400).json({ error: 'Missing date or dishName' });
-
         const db = await readDB();
-        db.meals = db.meals || {};
-        db.meals[date] = dishName; // Key by YYYY-MM-DD
+        const data = ensureFamilyData(db, req.user.familyId);
+        data.meals[date] = dishName;
         await writeDB(db);
         res.json({ success: true });
     } catch (error) {
@@ -68,13 +441,12 @@ app.post('/api/meals', async (req, res) => {
     }
 });
 
-// Delete a meal
-app.delete('/api/meals/:date', async (req, res) => {
+app.delete('/api/meals/:date', requireFamily, async (req, res) => {
     try {
-        const date = req.params.date;
         const db = await readDB();
-        if (db.meals && db.meals[date]) {
-            delete db.meals[date];
+        const data = ensureFamilyData(db, req.user.familyId);
+        if (data.meals && data.meals[req.params.date]) {
+            delete data.meals[req.params.date];
             await writeDB(db);
         }
         res.json({ success: true });
@@ -83,25 +455,29 @@ app.delete('/api/meals/:date', async (req, res) => {
     }
 });
 
-// Get all dishes
-app.get('/api/dishes', async (req, res) => {
+// ─── Dish Routes ─────────────────────────────────────────────────────────────
+
+app.get('/api/dishes', requireFamily, async (req, res) => {
     try {
         const db = await readDB();
-        res.json(db.dishes || []);
+        const data = ensureFamilyData(db, req.user.familyId);
+        res.json(data.dishes || []);
     } catch (error) {
         res.status(500).json({ error: error.message });
     }
 });
 
-// Add a dish
-app.post('/api/dishes', async (req, res) => {
+app.post('/api/dishes', requireFamily, async (req, res) => {
     try {
-        const dish = req.body;
-        // Assign ID
-        dish.id = Date.now().toString();
+        const dish = req.body || {};
+        if (!dish.name || !dish.name.trim()) return res.status(400).json({ error: 'Dish name required' });
+        dish.id = generateId('dish');
+        dish.tags = Array.isArray(dish.tags) ? dish.tags : [];
+        dish.ingredients = dish.ingredients && typeof dish.ingredients === 'object' ? dish.ingredients : {};
+        dish.createdAt = new Date().toISOString();
         const db = await readDB();
-        db.dishes = db.dishes || [];
-        db.dishes.push(dish);
+        const data = ensureFamilyData(db, req.user.familyId);
+        data.dishes.push(dish);
         await writeDB(db);
         res.json(dish);
     } catch (error) {
@@ -109,38 +485,35 @@ app.post('/api/dishes', async (req, res) => {
     }
 });
 
-// Update a dish
-app.put('/api/dishes/:id', async (req, res) => {
+app.put('/api/dishes/:id', requireFamily, async (req, res) => {
     try {
         const id = req.params.id;
-        const updatedDish = req.body;
+        const updates = req.body || {};
         const db = await readDB();
-        const index = db.dishes.findIndex(d => d.id === id);
-        if (index !== -1) {
-            db.dishes[index] = { ...db.dishes[index], ...updatedDish, id }; // Ensure ID matches
-            await writeDB(db);
-            res.json(db.dishes[index]);
-        } else {
-            res.status(404).json({ error: 'Dish not found' });
-        }
+        const data = ensureFamilyData(db, req.user.familyId);
+        const idx = data.dishes.findIndex((d) => d.id === id);
+        if (idx === -1) return res.status(404).json({ error: 'Dish not found' });
+        data.dishes[idx] = { ...data.dishes[idx], ...updates, id };
+        await writeDB(db);
+        res.json(data.dishes[idx]);
     } catch (error) {
         res.status(500).json({ error: error.message });
     }
 });
 
-// Delete a dish
-app.delete('/api/dishes/:id', async (req, res) => {
+app.delete('/api/dishes/:id', requireFamily, async (req, res) => {
     try {
         const id = req.params.id;
         const db = await readDB();
-        db.dishes = db.dishes.filter(d => d.id !== id);
-        // Also remove meals that use this dish?
-        // Optional cleanup
-        const dishName = db.dishes.find(d => d.id === id)?.name; // This logic is flawed if we already filtered it out
-        // Better logic: find name first
-        // But the user's original code handled deletion cleanup via separate calls or logic.
-        // Let's stick to simple dish deletion for now. The frontend might handle cleanup or we can add it later.
-
+        const data = ensureFamilyData(db, req.user.familyId);
+        const dish = data.dishes.find((d) => d.id === id);
+        data.dishes = data.dishes.filter((d) => d.id !== id);
+        // Remove meals that pointed at this dish (by name)
+        if (dish && data.meals) {
+            for (const [date, name] of Object.entries(data.meals)) {
+                if (name === dish.name) delete data.meals[date];
+            }
+        }
         await writeDB(db);
         res.json({ success: true });
     } catch (error) {
@@ -148,26 +521,29 @@ app.delete('/api/dishes/:id', async (req, res) => {
     }
 });
 
-// Get all tags
-app.get('/api/tags', async (req, res) => {
+// ─── Tag Routes ──────────────────────────────────────────────────────────────
+
+app.get('/api/tags', requireFamily, async (req, res) => {
     try {
         const db = await readDB();
-        res.json(db.tags || []);
+        const data = ensureFamilyData(db, req.user.familyId);
+        res.json(data.tags || []);
     } catch (error) {
         res.status(500).json({ error: error.message });
     }
 });
 
-// Add a tag
-app.post('/api/tags', async (req, res) => {
+app.post('/api/tags', requireFamily, async (req, res) => {
     try {
-        const tag = req.body; // { name: 'foo' }
-        tag.id = Date.now().toString();
+        const tag = req.body || {};
+        if (!tag.name || !tag.name.trim()) return res.status(400).json({ error: 'Tag name required' });
+        tag.name = tag.name.trim().toLowerCase();
+        tag.id = generateId('tag');
         const db = await readDB();
-        db.tags = db.tags || [];
-        // Check duplicates?
-        if (!db.tags.find(t => t.name.toLowerCase() === tag.name.toLowerCase())) {
-            db.tags.push(tag);
+        const data = ensureFamilyData(db, req.user.familyId);
+        data.tags = data.tags || [];
+        if (!data.tags.find((t) => t.name === tag.name)) {
+            data.tags.push(tag);
             await writeDB(db);
         }
         res.json(tag);
@@ -176,12 +552,12 @@ app.post('/api/tags', async (req, res) => {
     }
 });
 
-// Delete a tag
-app.delete('/api/tags/:id', async (req, res) => {
+app.delete('/api/tags/:id', requireFamily, async (req, res) => {
     try {
         const id = req.params.id;
         const db = await readDB();
-        db.tags = db.tags.filter(t => t.id !== id);
+        const data = ensureFamilyData(db, req.user.familyId);
+        data.tags = (data.tags || []).filter((t) => t.id !== id);
         await writeDB(db);
         res.json({ success: true });
     } catch (error) {
@@ -189,9 +565,34 @@ app.delete('/api/tags/:id', async (req, res) => {
     }
 });
 
-// Initialize and Listen
+// ─── Static Files + Auth Gate ────────────────────────────────────────────────
+
+const PUBLIC_PAGES = new Set(['/login', '/login.html', '/register', '/register.html']);
+const PUBLIC_ASSET_RE = /\.(css|js|png|jpe?g|svg|ico|webmanifest|json|woff2?|map)$/i;
+
+app.get(['/login', '/register'], (req, res) => {
+    res.sendFile(path.join(__dirname, req.path === '/register' ? 'register.html' : 'login.html'));
+});
+
+// Auth gate for HTML pages
+app.use((req, res, next) => {
+    if (req.method !== 'GET') return next();
+    if (req.path.startsWith('/api/')) return next();
+    if (PUBLIC_PAGES.has(req.path)) return next();
+    if (PUBLIC_ASSET_RE.test(req.path)) return next();
+    // Treat anything else without an asset extension as an HTML page
+    if (!req.user) {
+        return res.redirect('/login');
+    }
+    next();
+});
+
+app.use(express.static(__dirname, { index: 'index.html', extensions: ['html'] }));
+
+// ─── Boot ────────────────────────────────────────────────────────────────────
+
 initDB().then(() => {
     app.listen(PORT, () => {
-        console.log(`Server running on http://localhost:${PORT}`);
+        console.log(`MealFinderrz running on http://localhost:${PORT}`);
     });
 });

--- a/styles.css
+++ b/styles.css
@@ -1,1882 +1,1209 @@
-/* style.css */
+/* ================================================================
+   MealFinderrz — Design System
+   ================================================================ */
 
-/* Style for the clickable Dish Library heading */
-.dish-library h2#dishLibraryLink {
-  cursor: pointer;
-  display: inline-block;
-  padding: 8px 12px;
-  border: 1px solid #555;
-  background-color: #ffffff;
-  color: #333;
-  border-radius: 5px;
-  font-size: 1.1em;
-  font-weight: bold;
-  transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease-in-out;
-  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.05);
-  text-decoration: none;
+:root {
+  /* Brand */
+  --brand-blue: #072444;
+  --brand-blue-2: #0d3a6e;
+  --brand-yellow: #FFCB05;
+  --brand-yellow-soft: #FFF1B0;
+
+  /* Surfaces */
+  --bg: #F6F4EE;
+  --bg-2: #EFEAE0;
+  --surface: #FFFFFF;
+  --surface-2: #FAFAF7;
+  --overlay: rgba(7, 36, 68, 0.55);
+
+  /* Text */
+  --text: #18222F;
+  --text-soft: #4B5969;
+  --text-muted: #8593A4;
+  --text-on-brand: #FFCB05;
+  --on-yellow: #18222F;
+
+  /* Accents */
+  --accent: #E07A5F;
+  --accent-soft: #FBE3DB;
+  --success: #2E8B57;
+  --success-soft: #DCEFE3;
+  --danger: #C84E4E;
+  --danger-soft: #F7DCDC;
+
+  /* Borders */
+  --border: #E3DDD0;
+  --border-soft: #EFEBE0;
+
+  /* Effects */
+  --shadow-sm: 0 1px 2px rgba(15, 30, 60, 0.06);
+  --shadow-md: 0 6px 18px rgba(15, 30, 60, 0.08);
+  --shadow-lg: 0 18px 40px rgba(15, 30, 60, 0.18);
+
+  /* Geometry */
+  --radius-sm: 8px;
+  --radius: 14px;
+  --radius-lg: 22px;
+  --radius-pill: 999px;
+
+  /* Layout */
+  --content-max: 880px;
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --nav-height: 72px;
 }
 
-.dish-library h2#dishLibraryLink:hover {
-  background-color: #ddd;
-  color: #333;
-  transform: scale(1.02);
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.1);
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter",
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+  min-height: 100%;
 }
 
-.dish-library h2#dishLibraryLink:active {
-  transform: scale(0.98);
-}
-
-/* Keep your existing styles below */
 body {
-  font-family: sans-serif;
-  margin: 20px;
-  line-height: 1.6;
-  background-color: #ffffff;
-  color: #333;
-
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: calc(var(--nav-height) + 24px + var(--safe-bottom));
 }
 
-header {
+button { font-family: inherit; }
+a { color: var(--brand-blue-2); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+img { max-width: 100%; display: block; }
+
+/* ================================================================
+   Header
+   ================================================================ */
+
+.app-header {
+  background: linear-gradient(135deg, var(--brand-blue) 0%, var(--brand-blue-2) 100%);
+  color: var(--text-on-brand);
+  padding: 18px 20px calc(18px + env(safe-area-inset-top, 0px));
+  padding-top: calc(18px + env(safe-area-inset-top, 0px));
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 30px;
-  padding: 15px 20px;
-  background-color: #072444;
-  /* Fake blue to match icon */
-  color: #FFCB05;
-  border-radius: 5px;
+  gap: 12px;
+  border-bottom-left-radius: 24px;
+  border-bottom-right-radius: 24px;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  z-index: 5;
 }
 
-header h1 {
-  margin: 0;
-  font-size: 2em;
-}
-
-header h1 img {
-  height: 1.5em;
-  /* Match image height to h1 font size */
-  margin-right: 8px;
-  /* Adjust spacing between image and text */
-  vertical-align: middle;
-  /* Ensure vertical alignment */
-}
-
-/* DunkinNet Header Logo */
-.header-logo-link {
+.app-header .brand {
   display: flex;
   align-items: center;
+  gap: 12px;
+  min-width: 0;
 }
 
-.header-logo {
-  height: 40px;
-  width: auto;
-  border-radius: 5px;
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.header-logo:hover {
-  transform: scale(1.05);
-  opacity: 0.9;
-}
-
-body.grocery-page header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 30px;
-  padding: 15px 20px;
-  background-color: #072444;
-  /* Fake blue to match icon */
-  color: #FFCB05;
-  border-radius: 5px;
-}
-
-body.grocery-page header h1 {
-  margin: 0;
-  font-size: 2em;
-}
-
-header button {
-  padding: 10px 15px;
-  background-color: #293e52;
-  color: #FFCB05;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 1em;
-  transition: background-color 0.3s ease;
-}
-
-header button:hover {
-  background-color: #777;
-}
-
-.calendar-container {
-  margin-bottom: 30px;
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  padding: 20px;
-}
-
-.calendar-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 10px;
-  padding: 0;
-}
-
-.calendar-header button {
-  padding: 8px 17px;
-  background-color: #ddd;
-  color: #333;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 1.5em;
-  font-weight: bold;
-  transition: background-color 0.3s ease;
-}
-
-.calendar-header button:hover {
-  background-color: #ccc;
-}
-
-.calendar-header h2 {
-  margin: 0;
-  font-size: 1.5em;
-  color: #555;
-}
-
-.calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 8px;
-}
-
-.day {
-  padding: 15px;
-  border: 1px solid #eee;
-  text-align: center;
-  cursor: pointer;
-  background-color: #f9f9f9;
-  border-radius: 5px;
-  transition: background-color 0.2s ease;
-}
-
-.day:hover {
-  background-color: #e0e0e0;
-}
-
-.day.has-meal {
-  background-color: #d4edda;
-  color: #155724;
-  border-color: #c3e6cb;
-}
-
-.day.has-meal:hover {
-  background-color: #c1e1d1;
-}
-
-.day-content {
-  margin-top: 8px;
-  font-size: 0.9em;
-  font-weight: bold;
-}
-
-
-
-.add-meal-modal {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  justify-content: center;
-  align-items: center;
-  z-index: 10;
-}
-
-.modal-content {
-  background-color: white;
-  padding: 20px;
+.app-header .brand-icon {
+  width: 38px;
+  height: 38px;
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  position: relative;
-  max-width: 340px;
-  width: 85%;
-  height: 520px;
-  max-height: 85vh;
+  background: var(--brand-yellow);
+  color: var(--brand-blue);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  box-shadow: 0 4px 10px rgba(255, 203, 5, 0.35);
+  flex: 0 0 auto;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  color: var(--text-on-brand);
+  white-space: nowrap;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  text-overflow: ellipsis;
 }
 
-/* Mobile: Make modal wider and properly sized */
-@media (max-width: 480px) {
-  .modal-content {
-    width: 92%;
-    max-width: none;
-    margin: 0 15px;
-    height: 52vh;
-    overflow: hidden;
-  }
-
-  .select2-container--default .select2-results>.select2-results__options {
-    max-height: calc(75vh - 200px) !important;
-    overflow-y: auto !important;
-  }
-}
-
-/* Style adjustments for Select2 within the modal */
-.modal-content .select2-container {
-  width: 100% !important;
-  /* Make sure it takes the full width of the modal-content */
-}
-
-.modal-content .select2-dropdown {
-  width: 100% !important;
-  /* Ensure the dropdown doesn't extend beyond the modal-content width */
-  box-sizing: border-box;
-  /* Include padding and border in the element's total width and height */
-  /* You might need to adjust the z-index if it's still appearing behind other modal elements */
-  z-index: 100 !important;
-  /* Ensure it's above the modal (which has z-index: 10) */
-}
-
-.modal-content .select2-results__options {
-  box-sizing: border-box;
-  /* Apply box-sizing to the results list as well */
-}
-
-.select2-container--default .select2-search--dropdown .select2-search__field {
-  border: 1px solid #aaa;
-  font-size: 1.2em;
-  height: 45px !important;
-  width: 100% !important;
-  box-sizing: border-box;
-  padding: 8px 12px;
-}
-
-.select2-container--default .select2-selection--single {
-  display: none !important;
-}
-
-.select2-container--default .select2-selection--single .select2-selection__rendered {
-  color: #444;
-  line-height: 25px !important;
-}
-
-.select2-container--open .select2-dropdown--below {
-  position: relative !important;
-  margin-top: 5px;
-}
-
-#select2-selectDish-container {
-  display: none !important;
-  border: none !important;
-
-}
-
-.select2-container--default .select2-results>.select2-results__options {
-  max-height: 320px !important;
-  overflow-y: auto !important;
-}
-
-.select2-container--default .select2-results__option--highlighted.select2-results__option--selectable {
-  background-color: #00274C !important;
-  /* Active icon color */
-  color: #FFCB05 !important;
-  /* Active icon color */
-}
-
-.close-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  font-size: 1.5em;
-  cursor: pointer;
-  color: #888;
-}
-
-.close-button:hover {
-  color: #333;
-}
-
-.modal-content h3 {
-  margin-top: 0;
-  margin-bottom: 15px;
-  color: #00274C;
-  font-size: 1.2em;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  padding-right: 30px;
-  /* Space for close button */
-  line-height: 1.3;
-}
-
-.modal-content select {
-  width: 100%;
-  padding: 10px;
-  margin-bottom: 15px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 1em;
-}
-
-.modal-content button {
-  padding: 10px 15px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 1em;
-  transition: background-color 0.3s ease;
-}
-
-.modal-content button:hover {
-  background-color: #0056b3;
-}
-
-/* Random Meal Button */
-.random-meal-button {
-  width: 100%;
-  padding: 15px 20px;
-  margin-bottom: 15px;
-  background: linear-gradient(135deg, #00274C 0%, #003d73 100%);
-  color: #FFCB05;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-  font-size: 1.1em;
-  font-weight: bold;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 3px 8px rgba(0, 39, 76, 0.3);
-}
-
-.random-meal-button:hover {
-  transform: scale(1.02);
-  box-shadow: 0 5px 15px rgba(0, 39, 76, 0.4);
-  background: linear-gradient(135deg, #003d73 0%, #00274C 100%);
-}
-
-.random-meal-button:active {
-  transform: scale(0.98);
-}
-
-.random-meal-button i {
-  font-size: 1.3em;
-}
-
-/* ... other styles ... */
-
-
-
-#dishListManagement li button.delete-button:hover {
-  background-color: #c82333;
-}
-
-.add-new-dish-form {
-  display: grid;
-  gap: 10px;
-  margin-bottom: 20px;
-}
-
-.add-new-dish-form input[type="text"],
-.add-new-dish-form textarea {
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 1em;
-}
-
-.add-new-dish-form button {
-  padding: 10px 15px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 1em;
-  transition: background-color 0.3s ease;
-}
-
-.add-new-dish-form button:hover {
-  background-color: #0056b3;
-}
-
-
-#dishListManagement li button.edit-button {
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  padding: 5px 10px;
-  cursor: pointer;
-  font-size: 0.9em;
-  margin-right: 5px;
-  transition: background-color 0.3s ease;
-}
-
-#dishListManagement li button.edit-button:hover {
-  background-color: #0056b3;
-}
-
-#dishListManagement li button.delete-button {
-  background-color: #dc3545;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  padding: 5px 10px;
-  cursor: pointer;
-  font-size: 1em;
-  font-weight: bold;
-  transition: background-color 0.3s ease;
-}
-
-#dishListManagement li button.delete-button:hover {
-  background-color: #c82333;
-}
-
-#dishListManagement li>div {
-  display: flex;
-  gap: 5px;
-}
-
-
-.edit-dish-modal {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.edit-dish-modal .modal-content label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: bold;
-  color: #555;
-}
-
-.edit-dish-modal .modal-content input[type="text"],
-.edit-dish-modal .modal-content textarea {
-  width: calc(100% - 22px);
-  padding: 10px;
-  margin-bottom: 15px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  font-size: 1em;
-  box-sizing: border-box;
-}
-
-.edit-dish-modal .modal-content input[type="text"]:focus,
-.edit-dish-modal .modal-content textarea:focus {
-  outline: none;
-  border-color: #007bff;
-  box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
-}
-
-.edit-dish-modal .modal-content textarea {
-  min-height: 80px;
-}
-
-.edit-dish-modal button {
-  padding: 10px 15px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 1em;
-  transition: background-color 0.3s ease;
-}
-
-.edit-dish-modal button:hover {
-  background-color: #0056b3;
-}
-
-
-
-#dishListManagement {
-  list-style: none;
-  padding: 0;
-  margin-bottom: 20px;
-}
-
-#dishListManagement li {
-  padding: 8px 0;
-  border-bottom: 1px dashed #ddd;
-  display: flex;
-  align-items: baseline;
-  font-size: 1em;
-}
-
-#dishListManagement li:last-child {
-  border-bottom: none;
-}
-
-#dishListManagement li span.dish-name {
-  font-weight: bold;
-  color: #333;
-  margin-right: 1px;
-  flex-shrink: 0;
-  width: 100px;
-}
-
-#dishListManagement li span.ingredients {
-  color: #777;
-  font-style: italic;
-  white-space: pre-wrap;
-  word-break: break-word;
-  margin-left: 20px;
-  margin-right: 10px;
-}
-
-#dishListManagement li>div {
-  display: flex;
-  gap: 5px;
-  margin-left: auto;
-}
-
-
-.add-new-dish-form input[type="text"],
-.add-new-dish-form textarea {
-  padding: 8px;
-  border: 1px solid #aaa;
-  border-radius: 8px;
-  font-size: 1.1em;
-  margin-bottom: 15px;
-  box-sizing: border-box;
-  width: calc(100% - 24px);
-}
-
-.add-new-dish-form input[type="text"]:focus,
-.add-new-dish-form textarea:focus {
-  outline: none;
-  border-color: #007bff;
-  box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
-}
-
-.add-new-dish-form textarea {
-  min-height: 100px;
-  resize: vertical;
-}
-
-
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 1;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgba(0, 0, 0, 0.5);
-  justify-content: center;
-  align-items: center;
-}
-
-.modal-header {
-  padding: 10px 20px;
-  background-color: #f1f1f1;
-  border-bottom: 1px solid #ddd;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-}
-
-.modal-header h2 {
-  font-size: 1.5em;
-  margin: 0;
-}
-
-.modal-body {
-  padding: 20px;
-}
-
-.modal-footer {
-  padding: 10px 20px;
-  background-color: #f1f1f1;
-  border-top: 1px solid #ddd;
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  text-align: right;
-}
-
-.close {
-  color: #aaa;
-  float: right;
-  font-size: 28px;
-  font-weight: bold;
-  cursor: pointer;
-  position: absolute;
-  top: 10px;
-  right: 15px;
-}
-
-.close:hover,
-.close:focus {
-  color: black;
-  text-decoration: none;
-}
-
-
-#dishSearch {
-  width: calc(100% - 20px);
-  padding: 10px;
-  margin: 10px 0;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  font-size: 1em;
-  box-sizing: border-box;
-}
-
-#dishSearch:focus {
-  outline: none;
-  border-color: #007bff;
-  box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
-}
-
-
-#selectDish {
-  width: 100%;
-  padding: 10px;
-  margin: 5px 0 15px 0;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  font-size: 1em;
-  box-sizing: border-box;
-}
-
-#selectDish:focus {
-  outline: none;
-  border-color: #007bff;
-  box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
-}
-
-
-#saveMeal,
-#clearMeal {
-  background-color: #4CAF50;
-  color: white;
-  padding: 10px 15px;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1em;
-  margin-left: 10px;
-  transition: background-color 0.3s ease;
-}
-
-#saveMeal:hover,
-#clearMeal:hover {
-  background-color: #367c39;
-}
-
-#clearMeal {
-  background-color: #f44336;
-  color: white;
-}
-
-#clearMeal:hover {
-  background-color: #d32f2f;
-}
-
-/* Override transitions on the Select2 container when open */
-.modal-content .select2-container--open {
-  transition: none !important;
-  animation: none !important;
-}
-
-/* Also target the dropdown itself to be thorough */
-.modal-content .select2-container--open .select2-dropdown {
-  transition: none !important;
-  animation: none !important;
-}
-
-/* Make the select box itself clean */
-.select2-container--default .select2-selection--single {
-  background-color: #f8f8f8;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  height: 40px;
-  padding: 6px 12px;
-  font-size: 16px;
-}
-
-/* Text inside the selected box */
-.select2-container--default .select2-selection--single .select2-selection__rendered {
-  color: #333;
-  line-height: 26px;
-}
-
-/* Arrow icon */
-.select2-container--default .select2-selection--single .select2-selection__arrow {
-  height: 100%;
-  right: 10px;
-}
-
-/* Dropdown panel */
-.select2-container--default .select2-dropdown {
-  background-color: #fff;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-  z-index: 1011 !important;
-  /* stay on top */
-}
-
-/* Dropdown options */
-.select2-container--default .select2-results__option {
-  padding: 10px 12px;
-  font-size: 16px;
-}
-
-/* Hover & selected state */
-.select2-container--default .select2-results__option--highlighted {
-  background-color: #007bff;
-  color: white;
-}
-
-.select2-container--default .select2-results__option--selected {
-  background-color: #e9ecef;
-}
-
-.day.today {
-  background-color: #fcf29e;
-  /* Yellow background */
-  color: #000;
-  /* Black text */
-  font-weight: bold;
-  border: 2px solid #afa842;
-  /* Optional: Border for emphasis */
-}
-
-.day.today:hover {
-  background-color: #ffdd46;
-  /* Lighter yellow when hovered */
-}
-
-
-.bottom-navigation {
-  position: fixed;
-  bottom: 4.5%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 55%;
-  background-color: #ffffff;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: 7%;
-  padding: 10px 20px;
-  border-radius: 50px;
-  box-shadow: 0px -2px 10px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
-}
-
-/* Style for the colored circle behind the active button */
-.active-home-button::before {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 60px;
-  /* Adjust size to be slightly larger than the button */
-  height: 60px;
-  background-color: #00274C;
-  /* Your highlight color */
-  border-radius: 50%;
-  z-index: -1;
-  /* Behind the icon */
-}
-
-.active-grocery-button::before {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 83%;
-  transform: translate(-40%, -50%);
-  width: 60px;
-  /* Adjust size to be slightly larger than the button */
-  height: 60px;
-  background-color: #00274C;
-  /* Your highlight color */
-  border-radius: 50%;
-  z-index: -1;
-  /* Behind the icon */
-}
-
-.active-dish-button::before {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 13%;
-  transform: translate(-40%, -50%);
-  width: 60px;
-  /* Adjust size to be slightly larger than the button */
-  height: 60px;
-  background-color: #00274C;
-  /* Your highlight color */
-  border-radius: 50%;
-  z-index: -1;
-  /* Behind the icon */
-}
-
-/* Grocery buttons */
-
-
-
-
-#dishLibraryButton {
-  position: absolute;
-  /* Position relative to the nearest positioned ancestor */
-  left: 13%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-60%);
-  display: inline-block;
-  padding: 10px 20px;
-  margin: 5px;
-  /* Standard margins */
-  font-size: 2em;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 50px;
-  background-color: #ffffff;
-  color: #555;
-  cursor: pointer;
-  width: auto;
-}
-
-#active-dishLibraryButton {
-  position: absolute;
-  /* Position relative to the nearest positioned ancestor */
-  left: 13%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-60%);
-  display: inline-block;
-  padding: 10px 10px;
-  margin: 5px;
-  /* Standard margins */
-  font-size: 2em;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 50px;
-  color: #FFCB05;
-  /* Active icon color */
-  background-color: #00274C;
-  /* Active button color */
-  cursor: pointer;
-  width: auto;
-}
-
-#groceryListButton {
-  position: absolute;
-  /* Position relative to the nearest positioned ancestor */
-  left: 83%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-60%);
-  display: inline-block;
-  padding: 10px 20px;
-  margin: 5px;
-  /* Standard margins */
-  font-size: 2em;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 50px;
-  background-color: #ffffff;
-  color: #555;
-  cursor: pointer;
-  width: auto;
-}
-
-#active-groceryListButton {
-  position: absolute;
-  /* Position relative to the nearest positioned ancestor */
-  left: 83%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-60%);
-  display: inline-block;
-  padding: 10px 10px;
-  margin: 5px;
-  /* Standard margins */
-  font-size: 2em;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 50px;
-  color: #FFCB05;
-  /* Active icon color */
-  background-color: #00274C;
-  /* Active button color */
-  cursor: pointer;
-  width: auto;
-}
-
-#homeButton {
-  position: absolute;
-  /* Position relative to the nearest positioned ancestor */
-  left: 50%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-60%);
-  display: inline-block;
-  padding: 10px 20px;
-  margin: 5px 0 5px 0;
-  /* Add auto margin to the left */
-  font-size: 2em;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 50%;
-  background-color: #ffffff;
-  color: #555;
-  cursor: pointer;
-  width: auto;
-}
-
-#active-homeButton {
-  position: absolute;
-  /* Position relative to the nearest positioned ancestor */
-  left: 50%;
-  transform: translateX(-50%) translateY(-60%);
-  top: 50%;
-  display: block;
-  padding: 10px 10px;
-  margin: 5px 0 5px 0;
-  /* Add auto margin to the left */
-  font-size: 2em;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 50px;
-  color: #FFCB05;
-  /* Active icon color */
-  background-color: #00274C;
-  /* Active button color */
-  cursor: pointer;
-  width: auto;
-  border-radius: 50%;
-  /* Optional, for a circular container */
-}
-
-
-
-.dish-library-management {
-  margin: 5px 5px 150px 5px;
-}
-
-
-/* Meal Selection Page */
-#dishListContainer {
-  display: grid;
-  /* Use CSS Grid Layout */
-  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
-  /* Create responsive columns */
-  gap: 10px;
-  /* Spacing between grid items */
-  padding: 5px;
-  /* Padding around the grid */
-  margin-bottom: 200px;
-  /* Space for the bottom navigation bar */
-}
-
-.dish-item {
-  border: 1px solid #ddd;
-  background-color: #fff;
-  padding: 5px;
-  border-radius: 8px;
-  text-align: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  display: flex;
-  /* Enable Flexbox */
-  flex-direction: column;
-  /* Stack content vertically */
-  justify-content: space-between;
-  /* Distribute space */
-  height: 90%;
-  /* Ensure full height to push to bottom */
-  margin-bottom: 5px;
-  /* Add margin to the bottom of each item */
-}
-
-.dish-item h3 {
-  margin-top: 0;
-  margin-bottom: 5px;
-  color: #00274C;
-}
-
-.dish-item .tags {
-  color: #777;
-  font-size: 0.9em;
-  margin-top: auto;
-  margin-bottom: 0px;
-  font-style: italic;
-}
-
-/* Optional: Style for the rows if you were previously using them */
-.dish-row {
-  display: flex;
-  gap: 20px;
-  margin-bottom: 20px;
-  /* Adjust as needed */
-}
-
-.dish-row>.dish-item {
-  flex: 1;
-  /* Distribute space equally among items in a row */
-}
-
-.filter-section {
-  padding: 10px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  position: relative;
-  /* For positioning the popup */
-}
-
-.popup {
-  display: none;
-  /* Initially hidden */
-  position: absolute;
-  top: 100%;
-  /* Position below the button */
-  left: 0;
-  background-color: #f9f9f9;
-  border: 1px solid #ccc;
-  padding: 15px;
-  border-radius: 5px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-  z-index: 10;
-  /* Ensure it's above other content */
-  flex-direction: column;
-  gap: 10px;
-  align-items: flex-start;
-}
-
-.popup label {
-  font-weight: bold;
-}
-
-.current-dishes-header {
-  display: flex;
-  align-items: center;
-  /* Vertically align items in the center */
-  justify-content: space-between;
-  /* Distribute space between them */
-  gap: 20px;
-  /* Add some space between the items */
-}
-
-.current-dishes-header h2 {
-  margin-right: auto;
-  /* Push the heading to the left */
-}
-
-.current-dishes-header button {
-
-  border: none;
-  /* Remove the border */
-  border-radius: 5px;
-  /* Keep the border-radius if you like the rounded corners */
-  background-color: transparent;
-  /* Make the background transparent */
-  cursor: pointer;
-  font-size: 2.5em;
-  /* Make the text bigger */
-  color: #00274C;
-  /* Set the text color (you can choose any color) */
-}
-
-#openAddDishModal {
-  margin-left: 10px;
-  ;
-}
-
-.current-dishes-header button:hover {
-  background-color: rgba(0, 123, 255, 0.1);
-  /* Add a subtle background on hover for feedback */
-}
-
-
-.tag-popup {
-  display: none;
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background-color: #f9f9f9;
-  border: 1px solid #ccc;
-  padding: 15px;
-  border-radius: 5px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-  z-index: 10;
-  flex-direction: column;
-  /* Keep items stacked vertically */
-  gap: 15px;
-  /* Increased gap for better spacing between sections */
-  width: 100px;
-  /* Adjust width as needed */
-}
-
-.tag-popup .popup-header {
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  /* Left justify header content */
-  margin-bottom: 0;
-  /* Remove default bottom margin */
-}
-
-.tag-popup .popup-header button#clearFilter {
-  padding: 8px 12px;
-  border: 1px solid #bbb;
-  border-radius: 5px;
-  background-color: #eee;
-  cursor: pointer;
-  font-size: 0.9em;
-  width: 100%;
-  /* Make the button take full width */
-  text-align: left;
-  /* Left align the text inside the button */
-}
-
-.tag-popup .popup-header button#clearFilter:hover {
-  background-color: #ddd;
-}
-
-#tagButtonsContainer {
-  display: flex;
-  flex-direction: column;
-  /* Stack buttons vertically */
-  gap: 8px;
-  /* Space between tag buttons */
-  align-items: flex-start;
-  /* Left align tag buttons */
-}
-
-#tagButtonsContainer button {
-  padding: 8px 12px;
-  border: 1px solid #bbb;
-  border-radius: 5px;
-  background-color: #eee;
-  cursor: pointer;
-  font-size: 0.9em;
-  width: 100%;
-  /* Make buttons take full width */
-  text-align: left;
-  /* Left align text inside buttons */
-}
-
-#tagButtonsContainer button.active {
-  background-color: #00274C;
-  color: #FFCB05;
-  /* Active icon color */
-
-}
-
-.tag-popup .popup-footer {
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  /* Left justify footer content */
-  margin-top: 0;
-  /* Remove default top margin */
-}
-
-.tag-popup .popup-footer button#openAddTagPopup {
-  padding: 8px 15px;
-  border-radius: 5px;
-  color: #FFCB05;
-  /* Active icon color */
-  background-color: #00274C;
-  /* Active button color */
-  cursor: pointer;
-  font-size: 1em;
-  width: 100%;
-  /* Make button take full width */
-  text-align: left;
-  /* Left align text inside button */
-}
-
-.tag-popup .popup-footer button#openAddTagPopup:hover {
-  background-color: #0056b3;
-}
-
-/* Styles for the addTagPopup modal (reusing modal styles) */
-#addTagPopup.modal {
-  display: none;
-  /* Initially hidden */
-  position: fixed;
-  z-index: 11;
-  /* Higher than other modals */
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgba(0, 0, 0, 0.4);
-  /* Black w/ opacity */
-}
-
-#addTagPopup .modal-content {
-  background-color: #fefefe;
-  margin: 15% auto;
-  /* 15% from the top and centered */
-  padding: 20px;
-  border: 1px solid #888;
-  width: 80%;
-  /* Could be more or less, depending on screen size */
-  border-radius: 8px;
-  position: relative;
-}
-
-#addTagPopup .close-button {
-  color: #aaa;
-  float: right;
-  font-size: 28px;
-  font-weight: bold;
-}
-
-#addTagPopup .close-button:hover,
-#addTagPopup .close-button:focus {
-  color: black;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-#addTagPopup h3 {
-  margin-top: 0;
-  margin-bottom: 15px;
-  text-align: center;
-}
-
-#addTagPopup label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: bold;
-}
-
-#addTagPopup input[type=text] {
-  width: 100%;
-  padding: 10px;
-  margin-bottom: 15px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  box-sizing: border-box;
-}
-
-#addTagPopup button#saveNewTagButton {
-  background-color: #4CAF50;
-  color: white;
-  padding: 10px 15px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 1em;
-}
-
-#addTagPopup button#saveNewTagButton:hover {
-  background-color: #45a049;
-}
-
-#addTagPopup .add-new-tag {
-  margin-bottom: 20px;
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-#addTagPopup .add-new-tag input[type=text] {
-  flex-grow: 1;
-}
-
-
-
-
-
-/* Style for the modal content */
-#addDishModal .modal-content,
-#editDishModal .modal-content {
-  background-color: #fefefe;
-  margin: 5% auto;
-  /* Slightly reduce top margin */
-  padding: 15px;
-  /* Slightly reduce padding */
-  border: 1px solid #888;
-  width: 80%;
-  border-radius: 8px;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  /* Reduce gap between elements */
-  margin-bottom: 150px;
-  height: auto;
-
-}
-
-/* Style for the close button */
-#addDishModal .close-button,
-#editDishModal .close-button {
-  color: #aaa;
-  position: absolute;
-  right: 10px;
-  /* Slightly reduce right positioning */
-  top: 5px;
-  /* Slightly reduce top positioning */
-  font-size: 24px;
-  /* Slightly reduce font size */
-  font-weight: bold;
-  cursor: pointer;
-}
-
-#addDishModal .close-button:hover,
-#addDishModal .close-button:focus,
-#editDishModal .close-button:hover,
-#editDishModal .close-button:focus {
-  color: black;
-  text-decoration: none;
-}
-
-/* Style for the heading */
-#addDishModal h3,
-#editDishModal h3 {
-  margin-top: 0;
-  margin-bottom: 15px;
-  /* Reduce bottom margin */
-  text-align: center;
-  color: #333;
-  font-size: 1.5em;
-  /* Slightly reduce font size */
-}
-
-/* Style for labels */
-#addDishModal label,
-#editDishModal label {
-  margin-top: 15px;
-  /* Reduce top margin */
-  margin-bottom: 0px;
-  /* Reduce bottom margin */
-  color: #333;
-  font-size: 1.1em;
-  /* Slightly reduce font size */
-  font-weight: bold;
-}
-
-/* Style for input fields */
-#addDishModal input[type=text],
-#editDishModal input[type=text] {
-  width: calc(100% - 12px);
-  padding: 8px;
-  /* Reduce padding */
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  box-sizing: border-box;
-  font-size: 0.9em;
-  /* Reduce font size */
-}
-
-/* Style for the ingredients section heading */
-#addDishModal h4,
-#editDishModal h4:nth-of-type(1) {
-  margin-top: 15px;
-  /* Reduce top margin */
-  margin-bottom: 0px;
-  /* Reduce bottom margin */
-  color: #333;
-  font-size: 1.1em;
-  /* Slightly reduce font size */
-}
-
-/* Style for the add ingredient section */
-#addDishModal .add-ingredient,
-#editDishModal .add-ingredient {
-  display: flex;
-  gap: 8px;
-  /* Reduce gap */
-  margin-bottom: 10px;
-  /* Reduce bottom margin */
-  align-items: center;
-}
-
-#addDishModal .add-ingredient input[type=text],
-#editDishModal .add-ingredient input[type=text] {
-  flex-grow: 1;
-  padding: 8px;
-  /* Reduce padding */
-  font-size: 0.9em;
-  /* Reduce font size */
-}
-
-#addDishModal .add-ingredient button,
-#editDishModal .add-ingredient button {
-  padding: 8px 12px;
-  /* Reduce padding */
-  border-radius: 4px;
-  font-size: 0.9em;
-  /* Reduce font size */
-}
-
-/* Style for the ingredients list */
-#addDishModal #ingredientsList,
-#editDishModal #editIngredientsList {
-  margin-bottom: 10px;
-  /* Reduce bottom margin */
-  border: 1px solid #eee;
-  border-radius: 4px;
-}
-
-#addDishModal #ingredientsList li,
-#editDishModal #editIngredientsList li {
-  padding: 6px 0;
-  /* Reduce padding */
-  font-size: 0.9em;
-  /* Reduce font size */
-}
-
-#addDishModal #ingredientsList li button,
-#editDishModal #editIngredientsList li button {
-  padding: 4px 8px;
-  /* Reduce padding */
-  font-size: 1em;
-  /* Reduce font size */
-  margin-left: auto;
-  background-color: #f44336;
-  /* Red background for delete button */
-}
-
-#ingredientsList li,
-#editIngredientsList li {
-  display: flex;
-  justify-content: space-between;
-  /* Put space between text and button */
-  align-items: center;
-  /* Vertically align items */
-  padding: 8px 0;
-  border-bottom: 1px solid #eee;
-}
-
-#IngredientsList li div:last-child,
-#editIngredientsList li div:last-child {
-  /* Target the button's div */
-  padding: 4px 8px;
-  /* Reduce padding */
-  font-size: 0.7em;
-  /* Reduce font size */
-  margin-left: auto;
-}
-
-/* Style for the tags section heading */
-#editDishModal h4:nth-of-type(2) {
-  margin-top: 15px;
-  /* Reduce top margin */
-  margin-bottom: 8px;
-  /* Reduce bottom margin */
-  color: #333;
-  font-size: 1.1em;
-  /* Slightly reduce font size */
-}
-
-/* Style for the available tags dropdown */
-#addDishModal #availableTags,
-#editDishModal #editAvailableTags {
-  padding: 8px;
-  /* Reduce padding */
-  margin-bottom: 10px;
-  /* Reduce bottom margin */
-  font-size: 0.9em;
-  /* Reduce font size */
-}
-
-/* Style for the selected tags list */
-#addDishModal #selectedTagsList,
-#editDishModal #editSelectedTagsList {
-  gap: 3px;
-  /* Reduce gap */
-  margin-bottom: 10px;
-  /* Reduce bottom margin */
-  padding-left: 0px;
-}
-
-
-
-#addDishModal #selectedTagsList li button,
-#editDishModal #editSelectedTagsList li button {
-  font-size: 0.9em;
-  /* Adjust delete button size */
-  margin-left: auto;
-  /* Add a little space */
-}
-
-/* Style for the save buttons */
-#addDishModal button#addDishButton,
-#editDishModal button#saveEditedDishButton {
-  padding: 10px 15px;
-  /* Reduce padding */
-  font-size: 1em;
-  /* Reduce font size */
-}
-
-#addDishModal #selectedTagsList li,
-#editSelectedTagsList li {
+.app-header .header-actions {
   display: flex;
   align-items: center;
   gap: 8px;
-  /* Space between tag and button */
-  background-color: #e0f7fa;
-  color: #00838f;
-  border: 1px solid #b2ebf2;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 0.9em;
-  margin-right: 5px;
-  /* Space between tags */
-  margin-bottom: 5px;
-  /* Space between rows of tags */
+  flex: 0 0 auto;
 }
 
-#editSelectedTagsList li span i {
-  margin-right: 5px;
-  /* Space between the tag icon and text */
-}
-
-#editSelectedTagsList li button.remove-tag-button {
-  background: none;
-  border: none;
-  color: #d32f2f;
-  cursor: pointer;
-  font-size: 1em;
-  padding: 0;
-  line-height: 1;
-}
-
-#editSelectedTagsList li button.remove-tag-button:hover {
-  color: #b71c1c;
-}
-
-#selectedTagsList li {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  /* Space between tag and button */
-  background-color: #e0f7fa;
-  color: #00838f;
-  border: 1px solid #b2ebf2;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 0.9em;
-  margin-right: 5px;
-  /* Space between tags */
-  margin-bottom: 5px;
-  /* Space between rows of tags */
-}
-
-#selectedTagsList li span i {
-  margin-right: 5px;
-  /* Space between the tag icon and text */
-}
-
-#selectedTagsList li button.remove-tag-button {
-  background: none;
-  border: none;
-  color: #d32f2f;
-  cursor: pointer;
-  font-size: 1em;
-  padding: 0;
-  line-height: 1;
-}
-
-#selectedTagsList li button.remove-tag-button:hover {
-  color: #b71c1c;
-}
-
-#existingTagsList li {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  /* Space between tag and button */
-  background-color: #e0f7fa;
-  color: #00838f;
-  border: 1px solid #b2ebf2;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 0.9em;
-  margin-right: 5px;
-  /* Space between tags */
-  margin-bottom: 5px;
-  /* Space between rows of tags */
-}
-
-#existingTagsList li span i {
-  margin-right: 5px;
-  /* Space between the tag icon and text */
-}
-
-#existingTagsList li button.delete-tag-button {
-  background: none;
-  border: none;
-  color: #d32f2f;
-  cursor: pointer;
-  font-size: 1em;
-  padding: 0;
-  line-height: 1;
-}
-
-#existingTagsList li button.delete-tag-button:hover {
-  color: #b71c1c;
-}
-
-/* --- Grocery List Actions (Clear Button) --- */
-.grocery-list-actions {
-  text-align: center;
-  /* Center the button */
-  margin-bottom: 20px;
-  /* Add space below the button */
-}
-
-.grocery-list-actions #clearGroceryList {
-  padding: 10px 15px;
-  background-color: #dc3545;
-  /* Reddish button */
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 1em;
-  transition: background-color 0.3s ease;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.grocery-list-actions #clearGroceryList:hover {
-  background-color: #c82333;
-  /* Darker red on hover */
-}
-
-/* --- Grocery List Container and List --- */
-.grocery-list-container {
-  /* No container needed, let the ul take full width */
-  flex-grow: 1;
-  /* Allow the list to take up available vertical space */
-  margin-bottom: 80px;
-  /* IMPORTANT: Make space for fixed bottom navigation */
-  overflow-y: auto;
-  /* Make the list scrollable if it gets too long */
-  padding: 0 20px;
-  box-sizing: border-box;
-}
-
-#groceryList {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-#groceryList li {
-  padding: 12px 15px;
-  background-color: white;
-  margin-bottom: 10px;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  font-size: 1.3em;
-  display: flex;
-  /* Use flexbox for list item content */
-  align-items: center;
-  /* Vertically center the text and remove button */
-  justify-content: space-between;
-  /* Space between text and button */
-  border: 1px solid #ddd;
-}
-
-
-
-#groceryList li button {
-  padding: 5px 10px;
-  background-color: #dc3545;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 0.9em;
-  transition: background-color 0.3s ease;
-}
-
-#groceryList li button:hover {
-  background-color: #c82333;
-}
-
-/* --- New Checkbox Styles --- */
-#groceryList li input[type="checkbox"] {
-  position: relative;
-  cursor: pointer;
+.icon-btn {
   width: 40px;
   height: 40px;
-  appearance: none;
-  border: 2px solid #ccc;
-  border-radius: 50%;
-  /* Make it circular */
-  background-color: white;
-  transition: all 0.3s ease;
-  outline: none;
-  margin-left: 10px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-on-brand);
+  border: 1px solid rgba(255, 203, 5, 0.25);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  font-size: 1rem;
+}
+.icon-btn:hover { background: rgba(255, 255, 255, 0.18); }
+.icon-btn:active { transform: scale(0.94); }
+
+.header-logo-link img {
+  height: 36px;
+  width: auto;
+  border-radius: 8px;
+  transition: transform 0.15s, opacity 0.15s;
+}
+.header-logo-link:hover img { transform: scale(1.05); opacity: 0.95; }
+
+/* ================================================================
+   Page wrapper
+   ================================================================ */
+
+.page {
+  width: 100%;
+  max-width: var(--content-max);
+  margin: 0 auto;
+  padding: 16px;
+  flex: 1 0 auto;
 }
 
-#groceryList li input[type="checkbox"]:checked {
-  background-color: #00274C;
-  /* Change to blue */
-  border-color: #00274C;
-  /* Change to blue */
+.page-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 6px 0 12px;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-#groceryList li input[type="checkbox"]:checked::before {
-  content: "";
-  position: absolute;
-  top: 40%;
-  left: 50%;
-  transform: translate(-50%, -50%) rotate(45deg);
-  width: 12px;
-  height: 21px;
-  border: 4px solid #FFCB05;
-  /* Change to yellow */
-  border-top: none;
-  border-left: none;
+/* ================================================================
+   Card
+   ================================================================ */
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: 18px;
 }
 
-#groceryList li input[type="checkbox"]:hover {
-  border-color: #00274C;
-  /* Change to blue */
+/* ================================================================
+   Calendar
+   ================================================================ */
+
+.calendar-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: 14px;
+  margin-bottom: 18px;
 }
 
-#groceryList li input[type="checkbox"]:focus {
-  box-shadow: 0 0 0 2px rgba(0, 39, 76, 0.5);
-  /* Use a blue shadow */
+.calendar-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
 }
 
-/* Focus effect */
-#groceryList li input[type="checkbox"]:focus {
-  box-shadow: 0 0 0 2px rgba(0, 39, 76, 0.5);
-  /* Add a blue shadow for focus */
+.calendar-toolbar h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+  flex: 1;
+  text-align: center;
 }
 
-/* on phone specific */
+.calendar-nav-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  display: grid;
+  place-items: center;
+}
+.calendar-nav-btn:hover { background: var(--bg-2); }
+.calendar-nav-btn:active { transform: scale(0.94); }
+
+.today-btn {
+  height: 32px;
+  padding: 0 14px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-soft);
+  font-weight: 600;
+  font-size: 0.78rem;
+  cursor: pointer;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.today-btn:hover { background: var(--brand-yellow-soft); color: var(--brand-blue); border-color: var(--brand-yellow); }
 
 .calendar-weekdays {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   text-align: center;
-  font-weight: bold;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-muted);
+  padding: 6px 0 8px;
+  border-bottom: 1px dashed var(--border);
+  margin-bottom: 8px;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+}
+
+.day {
+  position: relative;
+  background: var(--surface-2);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  cursor: pointer;
+  min-height: 78px;
+  padding: 6px 6px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: hidden;
+  transition: background 0.15s, border-color 0.15s, transform 0.1s;
+}
+.day:hover { background: var(--bg-2); }
+.day:active { transform: scale(0.98); }
+
+.day.empty {
+  background: transparent;
+  border: 0;
+  cursor: default;
+  pointer-events: none;
+}
+
+.day-num {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-soft);
+  align-self: flex-start;
+  line-height: 1;
+}
+
+.day .meal {
+  margin-top: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--brand-blue);
+  background: var(--brand-yellow-soft);
+  border-radius: 8px;
+  padding: 4px 6px;
+  /* Constrain to two lines with ellipsis to prevent overflow */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+  flex: 1;
+  min-height: 0;
+}
+
+.day.today {
+  background: linear-gradient(180deg, var(--brand-yellow-soft) 0%, var(--surface-2) 70%);
+  border-color: var(--brand-yellow);
+  box-shadow: inset 0 0 0 1px var(--brand-yellow);
+}
+.day.today .day-num {
+  color: var(--brand-blue);
+  background: var(--brand-yellow);
+  border-radius: var(--radius-pill);
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+}
+
+.day.has-meal { background: var(--surface); }
+.day.other-month { opacity: 0.45; }
+
+@media (max-width: 600px) {
+  .day { min-height: 64px; padding: 5px 4px 6px; }
+  .day-num { font-size: 0.7rem; }
+  .day .meal { font-size: 0.62rem; padding: 2px 4px; -webkit-line-clamp: 2; border-radius: 6px; }
+  .calendar-card { padding: 10px; border-radius: 18px; }
+  .calendar-grid { gap: 4px; }
+}
+
+/* ================================================================
+   Bottom Navigation
+   ================================================================ */
+
+.bottom-nav {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(14px + var(--safe-bottom));
+  width: min(360px, calc(100% - 28px));
+  height: var(--nav-height);
+  background: var(--surface);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 0 12px;
+  z-index: 50;
+  border: 1px solid var(--border);
+}
+
+.bottom-nav a {
+  flex: 1;
+  height: 56px;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  border-radius: var(--radius-pill);
+  font-size: 1.25rem;
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s, transform 0.1s;
+  position: relative;
+}
+.bottom-nav a:hover { color: var(--brand-blue); }
+.bottom-nav a:active { transform: scale(0.94); }
+
+.bottom-nav a.active {
+  background: var(--brand-blue);
+  color: var(--brand-yellow);
+  box-shadow: 0 6px 14px rgba(7, 36, 68, 0.35);
+}
+
+.bottom-nav a span.label {
+  position: absolute;
+  bottom: 4px;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  font-weight: 700;
+  opacity: 0;
+}
+.bottom-nav a.active span.label { opacity: 1; }
+.bottom-nav a:not(.active) i { transform: translateY(0); }
+.bottom-nav a.active i { transform: translateY(-6px); }
+
+/* ================================================================
+   Modals (no jQuery / Select2; native CSS)
+   ================================================================ */
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  display: none;
+  z-index: 200;
+  align-items: flex-end;
+  justify-content: center;
   padding: 0;
-  border-bottom: 1px solid #ccc;
+  animation: fade-in 0.18s ease-out;
+}
+.modal.open { display: flex; }
+
+.modal .sheet {
+  background: var(--surface);
+  width: 100%;
+  max-width: 520px;
+  max-height: 90vh;
+  border-radius: 22px 22px 0 0;
+  padding: 22px 18px calc(18px + var(--safe-bottom));
+  box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  animation: slide-up 0.22s ease-out;
+  overflow: hidden;
 }
 
-.calendar-weekdays div {
+@media (min-width: 720px) {
+  .modal { align-items: center; padding: 24px; }
+  .modal .sheet { border-radius: var(--radius-lg); max-width: 540px; }
+}
+
+.modal .sheet-grabber {
+  width: 38px;
+  height: 4px;
+  background: var(--border);
+  border-radius: 999px;
+  align-self: center;
+  margin: -8px 0 4px;
+}
+
+.modal .sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.modal .sheet-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.modal .sheet-close {
+  background: transparent;
+  border: 0;
+  font-size: 1.4rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+  line-height: 1;
+}
+.modal .sheet-close:hover { color: var(--text); background: var(--bg-2); }
+
+.modal .sheet-body {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-right: 2px;
+}
+
+@keyframes slide-up {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ================================================================
+   Buttons
+   ================================================================ */
+
+.btn {
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 12px 18px;
+  border-radius: var(--radius-pill);
+  background: var(--brand-blue);
+  color: var(--text-on-brand);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: transform 0.1s, background 0.15s, box-shadow 0.15s;
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+}
+.btn:hover { background: var(--brand-blue-2); }
+.btn:active { transform: scale(0.97); }
+.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.btn.btn-block { width: 100%; }
+.btn.btn-secondary {
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.btn.btn-secondary:hover { background: var(--bg-2); }
+.btn.btn-yellow {
+  background: var(--brand-yellow);
+  color: var(--on-yellow);
+}
+.btn.btn-yellow:hover { background: #FFD42A; }
+.btn.btn-danger {
+  background: var(--danger);
+  color: white;
+}
+.btn.btn-danger:hover { background: #B43F3F; }
+.btn.btn-ghost {
+  background: transparent;
+  color: var(--text-soft);
+  box-shadow: none;
+}
+.btn.btn-ghost:hover { background: var(--bg-2); color: var(--text); }
+
+.btn.btn-lg { padding: 14px 22px; font-size: 1rem; }
+.btn.btn-sm { padding: 8px 14px; font-size: 0.85rem; }
+
+.random-btn {
+  width: 100%;
+  background: linear-gradient(135deg, var(--accent) 0%, #C25E45 100%);
+  color: white;
+  border: 0;
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  font-weight: 700;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(224, 122, 95, 0.32);
+  transition: transform 0.1s, box-shadow 0.15s, filter 0.15s;
+}
+.random-btn:hover { filter: brightness(1.04); box-shadow: 0 12px 24px rgba(224, 122, 95, 0.4); }
+.random-btn:active { transform: scale(0.98); }
+
+/* ================================================================
+   Forms
+   ================================================================ */
+
+.field { display: flex; flex-direction: column; gap: 6px; }
+.field label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-soft);
+  letter-spacing: 0.2px;
+}
+.input, .textarea, select.input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.textarea { min-height: 90px; resize: vertical; }
+.input:focus, .textarea:focus, select.input:focus {
+  outline: none;
+  border-color: var(--brand-blue-2);
+  box-shadow: 0 0 0 3px rgba(13, 58, 110, 0.15);
+}
+
+.field-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.field-row .input { flex: 1; }
+
+.help { font-size: 0.78rem; color: var(--text-muted); }
+.error-text { font-size: 0.85rem; color: var(--danger); }
+
+/* ================================================================
+   Search dish list (replacement for select2)
+   ================================================================ */
+
+.dish-search-input {
+  width: 100%;
+  padding: 13px 14px 13px 42px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface-2)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%238593A4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='7'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>")
+    no-repeat 14px center;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+.dish-search-input:focus { outline: none; border-color: var(--brand-blue-2); box-shadow: 0 0 0 3px rgba(13, 58, 110, 0.15); }
+
+.dish-pick-list {
+  list-style: none;
+  margin: 0;
   padding: 0;
-  color: #333;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--surface);
+}
+.dish-pick-list li {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background 0.1s;
+}
+.dish-pick-list li:last-child { border-bottom: 0; }
+.dish-pick-list li:hover, .dish-pick-list li.active {
+  background: var(--brand-yellow-soft);
+}
+.dish-pick-list li.selected::after {
+  content: "✓";
+  margin-left: auto;
+  color: var(--brand-blue);
+  font-weight: 700;
+}
+.dish-pick-list .empty { color: var(--text-muted); cursor: default; justify-content: center; }
+
+.clear-meal-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 6px;
+  margin-top: 4px;
+  border-top: 1px dashed var(--border);
 }
 
-/* Highlight weekends with a slightly lighter gray */
-.calendar-weekdays div:first-child,
-/* Sunday */
-.calendar-weekdays div:last-child {
-  /* Saturday */
-  color: #777;
+/* ================================================================
+   Auth pages
+   ================================================================ */
+
+.auth-page {
+  min-height: 100vh;
+  background: linear-gradient(160deg, var(--brand-blue) 0%, var(--brand-blue-2) 60%, #1F4D8A 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px calc(32px + var(--safe-bottom));
+  color: var(--text);
+  padding-bottom: 0;
+}
+.auth-page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 10%, rgba(255, 203, 5, 0.18), transparent 40%),
+              radial-gradient(circle at 80% 90%, rgba(255, 203, 5, 0.12), transparent 40%);
+  pointer-events: none;
+  z-index: 0;
 }
 
-@media (max-width: 768px) {
+.auth-card {
+  position: relative;
+  z-index: 1;
+  background: var(--surface);
+  width: 100%;
+  max-width: 420px;
+  border-radius: var(--radius-lg);
+  padding: 28px 24px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.auth-card .auth-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+.auth-card .auth-brand .brand-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: var(--brand-blue);
+  color: var(--brand-yellow);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+}
+.auth-card h1 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--brand-blue);
+  letter-spacing: 0.3px;
+}
+.auth-card .subtitle { margin: 0; color: var(--text-soft); font-size: 0.9rem; }
 
-  /* Adjust calendar size for mobile */
-  body {
-    background-color: #2F65A7 !important;
-    margin: 0px !important;
-    /* Reduce margin on mobile */
-  }
+.auth-tabs {
+  display: flex;
+  background: var(--bg-2);
+  border-radius: var(--radius-pill);
+  padding: 4px;
+  margin-bottom: 4px;
+}
+.auth-tabs button {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  padding: 9px 12px;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-soft);
+  cursor: pointer;
+}
+.auth-tabs button.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
 
-  header {
-    margin-bottom: 5px !important;
-    padding: 2px 20px 15px 20px;
-    border-radius: 0px;
-  }
+.auth-footer {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-soft);
+  margin-top: 6px;
+}
 
+/* ================================================================
+   Toasts
+   ================================================================ */
 
+.toast-host {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 16px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  width: min(420px, calc(100% - 32px));
+}
+.toast {
+  background: var(--text);
+  color: white;
+  padding: 11px 14px;
+  border-radius: var(--radius);
+  font-size: 0.88rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity 0.18s, transform 0.18s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  pointer-events: auto;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+.toast.success { background: var(--success); }
+.toast.error { background: var(--danger); }
+.toast.info { background: var(--brand-blue); color: var(--brand-yellow); }
 
-  body.grocery-page header {
-    margin-bottom: 30px;
-    padding: 2px 20px 15px 20px;
-    border-radius: 0px;
-  }
+/* ================================================================
+   Dish Library
+   ================================================================ */
 
-  .calendar-container {
-    margin-left: 6px;
-    /* Reduce left margin */
-    margin-right: 6px;
-    /* Reduce right margin */
-    margin-bottom: 5px !important;
-    padding: 5px;
-    /* Slightly reduce padding inside */
-  }
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.toolbar .search-input {
+  flex: 1;
+  padding: 12px 14px 12px 40px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--surface)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238593A4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='7'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>")
+    no-repeat 14px center;
+  font-size: 0.92rem;
+  font-family: inherit;
+}
+.toolbar .search-input:focus {
+  outline: none;
+  border-color: var(--brand-blue-2);
+  box-shadow: 0 0 0 3px rgba(13, 58, 110, 0.12);
+}
 
-  .calendar-grid {
-    gap: 2px;
-    /* Reduce gap between days */
-  }
+.toolbar-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--brand-blue);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.15s, color 0.15s;
+}
+.toolbar-btn:hover { background: var(--brand-yellow-soft); }
+.toolbar-btn.primary {
+  background: var(--brand-blue);
+  color: var(--brand-yellow);
+  border-color: transparent;
+}
+.toolbar-btn.primary:hover { background: var(--brand-blue-2); }
 
-  .day {
-    padding: 2px;
-    /* Reduce padding inside each day cell */
-    font-size: 1rem;
-    /* Smaller font size for day numbers */
-    font-weight: bold;
-    /* Make day numbers bold */
-    min-height: 80px;
-    /* Ensure a minimum height for day cells */
-  }
+.tag-filter-row {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 4px 4px 12px;
+  margin: 0 -4px 6px;
+  scrollbar-width: none;
+}
+.tag-filter-row::-webkit-scrollbar { display: none; }
+.tag-chip {
+  white-space: nowrap;
+  padding: 7px 14px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.tag-chip:hover { background: var(--bg-2); }
+.tag-chip.active {
+  background: var(--brand-blue);
+  color: var(--brand-yellow);
+  border-color: transparent;
+}
 
-  .day-content {
-    font-size: 0.8rem;
-    /* Smaller font size for day content */
-  }
+.dish-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+}
 
-  .fc-toolbar-title {
-    font-size: 1rem;
-    /* smaller month title */
-  }
+.dish-card {
+  background: var(--surface);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  padding: 14px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 90px;
+  transition: transform 0.12s, box-shadow 0.15s, border-color 0.15s;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+.dish-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--brand-yellow);
+}
+.dish-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.25;
+  word-break: break-word;
+}
+.dish-card .dish-tags {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: auto;
+}
+.dish-card .pill {
+  font-size: 0.68rem;
+  padding: 3px 7px;
+  border-radius: var(--radius-pill);
+  background: var(--brand-yellow-soft);
+  color: var(--brand-blue);
+  font-weight: 700;
+  letter-spacing: 0.2px;
+}
 
-  .fc-daygrid-day-number {
-    font-size: 0.5rem;
-  }
+/* ================================================================
+   Tag list / chips inside modals
+   ================================================================ */
 
-  .fc-event {
-    font-size: 0.5rem;
-    padding: 1px 2px;
-  }
+.chip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chip-list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px 6px 12px;
+  border-radius: var(--radius-pill);
+  background: var(--brand-yellow-soft);
+  color: var(--brand-blue);
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: 1px solid var(--brand-yellow);
+}
+.chip-list .remove {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--brand-blue);
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 2px;
+  border-radius: 999px;
+}
+.chip-list .remove:hover { background: rgba(0, 0, 0, 0.06); }
 
-  .fc {
-    transform: scale(0.95);
-    transform-origin: top center;
-  }
+.ingredient-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ingredient-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+}
+.ingredient-list li .ing-name { font-weight: 600; flex: 1; word-break: break-word; }
+.ingredient-list li .ing-qty { color: var(--text-soft); font-size: 0.85rem; }
+.ingredient-list li .actions { display: flex; gap: 4px; margin-left: auto; }
+.ingredient-list li button {
+  background: transparent;
+  border: 0;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--text-soft);
+  cursor: pointer;
+}
+.ingredient-list li button:hover { background: var(--bg-2); color: var(--text); }
+.ingredient-list li button.danger:hover { color: var(--danger); background: var(--danger-soft); }
 
+.empty-state {
+  padding: 40px 16px;
+  text-align: center;
+  color: var(--text-muted);
+}
+.empty-state .icon {
+  font-size: 2.4rem;
+  margin-bottom: 10px;
+  color: var(--brand-yellow);
+}
+.empty-state h3 { margin: 6px 0; color: var(--text); font-weight: 700; font-size: 1.05rem; }
+.empty-state p { margin: 0 0 12px; font-size: 0.9rem; }
 
+/* ================================================================
+   Grocery list
+   ================================================================ */
 
+.grocery-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  gap: 12px;
+}
+.grocery-summary .stats {
+  font-size: 0.85rem;
+  color: var(--text-soft);
+}
+
+.grocery-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.grocery-list li {
+  background: var(--surface);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+.grocery-list li:hover { background: var(--surface-2); }
+.grocery-list li.checked {
+  background: var(--surface-2);
+  opacity: 0.55;
+}
+.grocery-list li.checked .name { text-decoration: line-through; }
+
+.grocery-checkbox {
+  appearance: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  background: var(--surface);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  position: relative;
+  transition: background 0.15s, border-color 0.15s;
+  flex: 0 0 auto;
+}
+.grocery-checkbox:checked {
+  background: var(--brand-blue);
+  border-color: var(--brand-blue);
+}
+.grocery-checkbox:checked::after {
+  content: "";
+  width: 7px;
+  height: 12px;
+  border-right: 2.5px solid var(--brand-yellow);
+  border-bottom: 2.5px solid var(--brand-yellow);
+  transform: rotate(45deg) translate(-1px, -1px);
+}
+.grocery-list .name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+  word-break: break-word;
+}
+.grocery-list .qty {
+  font-size: 0.82rem;
+  color: var(--text-soft);
+  background: var(--bg-2);
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+
+/* ================================================================
+   Family page
+   ================================================================ */
+
+.family-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.family-card .invite-row {
+  background: linear-gradient(135deg, var(--brand-yellow-soft), #FFE894);
+  border: 1px dashed var(--brand-yellow);
+  padding: 14px 16px;
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.family-card .invite-row .label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.6px;
+  font-weight: 700;
+  color: var(--brand-blue);
+  margin-bottom: 2px;
+}
+.family-card .invite-row code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--brand-blue);
+  letter-spacing: 4px;
+}
+
+.member-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.member-list li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+}
+.member-list .avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--brand-blue);
+  color: var(--brand-yellow);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  flex: 0 0 auto;
+}
+.member-list .name { font-weight: 600; }
+.member-list .meta { font-size: 0.78rem; color: var(--text-muted); }
+.member-list .owner-tag {
+  margin-left: auto;
+  font-size: 0.7rem;
+  font-weight: 700;
+  background: var(--brand-yellow);
+  color: var(--brand-blue);
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  letter-spacing: 0.4px;
+}
+
+.section-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-muted);
+  margin: 18px 0 8px;
+}
+
+/* ================================================================
+   Misc
+   ================================================================ */
+
+.skel {
+  background: linear-gradient(90deg, var(--bg-2) 0%, var(--surface) 50%, var(--bg-2) 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
+  border-radius: var(--radius);
+}
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.divider { height: 1px; background: var(--border-soft); margin: 4px 0; }
+
+@media (max-width: 600px) {
+  .page { padding: 12px; }
+  .auth-card { padding: 22px 18px; }
+  .dish-grid { grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); gap: 8px; }
 }


### PR DESCRIPTION
## Summary

Major rewrite turning MealFinderrz into a real multi-user app for friends and family, plus a top-to-bottom UI overhaul.

- **Auth + families.** Cookie-session auth (`cookie-session` + `bcryptjs`). Each user belongs to one family; families have a 6-character invite code. All meals, dishes, and tags are scoped to the user's family, so my wife and I can share a calendar while other users keep their own.
- **Calendar overflow fixed.** Meal text now uses `-webkit-line-clamp` with ellipsis (3 lines on desktop, 2 on mobile) and never bleeds out of a day cell. Added a Today jump button, weekend de-emphasis, and a yellow-pill "today" indicator.
- **No more jQuery / Select2.** Replaced with a native bottom-sheet picker (search input + scrollable dish list + "Surprise me" + "Clear meal").
- **Full design system rewrite.** CSS variables for a warm cream + brand-blue + yellow palette, floating pill bottom-nav, toast notifications instead of `alert()`, safe-area-inset support for iOS, skeleton loaders, friendly empty states.
- **New pages:** `/login`, `/register` (tabbed Create or Join family), `/family` (rename, regenerate invite code, member list, change display name + password, leave family).
- **Auto-migration** for the existing live deploy: a v1 `db.json` is migrated on startup into a claimable `family-legacy` family with a printed invite code. The first user to register with that code via "Join with code" claims ownership and inherits all old meals/dishes/tags. No data loss.

## Reviewer notes

- **New deps:** `bcryptjs`, `cookie-session`. Lockfile regenerated.
- **Session secret:** uses `SESSION_SECRET` env if present; otherwise generates one and persists it to `data/.session-key` (mode 0600). Sessions survive container restarts as long as `data/` does.
- **Static-page auth gate:** anonymous GETs other than `/login`, `/register`, and assets redirect to `/login`. API requests return `401`.
- **Atomic writes:** every `writeDB` writes to `db.json.tmp` then renames, behind a serialized promise queue, so concurrent requests can't corrupt the file.
- **Dockerfile:** unchanged — its glob copies (`*.html`, `*.js`, `*.css`, `*.json`, `*.png`) already include the new files.
- **Compose:** consider adding `SESSION_SECRET` to the deploy `.env`, but it's optional (falls back to disk).

## Test plan

- [x] Anonymous `/api/meals` -> 401; anonymous `/` and `/family` -> 302 to `/login`
- [x] Register Alice (creates family); register Bob with her code (joins, sees her data); register Carol in her own family (data isolated)
- [x] Bad invite code -> 404; duplicate username -> 409; short password -> 400; wrong password on login -> 401
- [x] Logout clears session; login restores it
- [x] Legacy v1 db.json migrates to claimable family-legacy; first user with the code claims ownership and inherits all data
- [ ] Manual smoke on the deployed VM after image rebuild: register, calendar, dishes, grocery, family pages on mobile + desktop