### PR TITLE
Cache app shell + API data for snappy tab-switching on iPhone

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,47 @@
 // Shared client utilities — toasts, fetch wrapper, modal helpers, auth.
 
+// ─── Service worker (snappy tab-switching on iPhone) ────────────────
+
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(() => {});
+    });
+}
+
+// ─── Stale-while-revalidate cache for GETs ──────────────────────────
+
+const CACHE_PREFIX = 'mfz:';
+const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 1 day
+
+export const cache = {
+    get(key) {
+        try {
+            const raw = sessionStorage.getItem(CACHE_PREFIX + key);
+            if (!raw) return null;
+            const { ts, value } = JSON.parse(raw);
+            if (Date.now() - ts > CACHE_TTL_MS) return null;
+            return value;
+        } catch {
+            return null;
+        }
+    },
+    set(key, value) {
+        try {
+            sessionStorage.setItem(CACHE_PREFIX + key, JSON.stringify({ ts: Date.now(), value }));
+        } catch {}
+    },
+    clear() {
+        try {
+            const keys = [];
+            for (let i = 0; i < sessionStorage.length; i++) {
+                const k = sessionStorage.key(i);
+                if (k && k.startsWith(CACHE_PREFIX)) keys.push(k);
+            }
+            keys.forEach((k) => sessionStorage.removeItem(k));
+        } catch {}
+    },
+};
+
 export const api = {
     async request(path, opts = {}) {
         const headers = { 'Accept': 'application/json', ...(opts.headers || {}) };
@@ -12,6 +54,7 @@ export const api = {
         const data = ct.includes('application/json') ? await res.json().catch(() => null) : null;
         if (!res.ok) {
             if (res.status === 401) {
+                cache.clear();
                 if (!location.pathname.startsWith('/login')) {
                     location.href = '/login';
                 }
@@ -29,6 +72,32 @@ export const api = {
     put: (p, body) => api.request(p, { method: 'PUT', body }),
     del: (p) => api.request(p, { method: 'DELETE' }),
 };
+
+// Stale-while-revalidate GET. Returns the cached value immediately if present
+// (or awaits the network if not), and calls onFresh(data) later if the network
+// response differs from the cached one. Use this for snappy first-paint.
+export async function cachedGet(path, onFresh) {
+    const key = 'GET:' + path;
+    const cached = cache.get(key);
+    const networkPromise = api
+        .get(path)
+        .then((data) => {
+            cache.set(key, data);
+            return data;
+        });
+
+    if (cached !== null && cached !== undefined) {
+        networkPromise
+            .then((fresh) => {
+                if (typeof onFresh === 'function' && JSON.stringify(fresh) !== JSON.stringify(cached)) {
+                    onFresh(fresh);
+                }
+            })
+            .catch(() => {});
+        return cached;
+    }
+    return networkPromise;
+}
 
 // ─── Toasts ──────────────────────────────────────────────────────────
 
@@ -110,6 +179,7 @@ export function renderHeader({ title, icon = 'fa-utensils', user } = {}) {
             try {
                 await api.post('/api/auth/logout', {});
             } finally {
+                cache.clear();
                 location.href = '/login';
             }
         });
@@ -138,12 +208,44 @@ export function renderBottomNav(active) {
 // ─── Auth bootstrap ─────────────────────────────────────────────────
 
 export async function requireUser() {
+    const cached = cache.get('user');
+    const revalidate = async () => {
+        try {
+            const { user } = await api.get('/api/auth/me');
+            if (!user) {
+                cache.clear();
+                location.href = '/login';
+                return null;
+            }
+            cache.set('user', user);
+            if (!user.familyId && !location.pathname.startsWith('/family')) {
+                location.href = '/family';
+            }
+            return user;
+        } catch {
+            return null;
+        }
+    };
+
+    if (cached) {
+        // Return cached user immediately so the page paints without waiting
+        // for the network. Verify in the background and only redirect on a
+        // confirmed 401 (auth wrapper handles that).
+        revalidate();
+        if (!cached.familyId && !location.pathname.startsWith('/family')) {
+            location.href = '/family';
+            return cached;
+        }
+        return cached;
+    }
+
     try {
         const { user } = await api.get('/api/auth/me');
         if (!user) {
             location.href = '/login';
             return null;
         }
+        cache.set('user', user);
         if (!user.familyId && !location.pathname.startsWith('/family')) {
             location.href = '/family';
             return user;

--- a/dishes.html
+++ b/dishes.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Dish Library · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=22" />
+    <link rel="stylesheet" href="styles.css?v=23" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#072444" />
     <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
           referrerpolicy="no-referrer" />
 </head>
@@ -88,6 +89,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="dishes.js?v=22"></script>
+    <script type="module" src="dishes.js?v=23"></script>
 </body>
 </html>

--- a/dishes.js
+++ b/dishes.js
@@ -1,4 +1,4 @@
-import { api, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser } from './app.js?v=22';
+import { api, cache, cachedGet, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser } from './app.js?v=23';
 
 let allDishes = [];
 let allTags = [];
@@ -14,13 +14,30 @@ function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-async function loadAll() {
-    [allDishes, allTags] = await Promise.all([
-        api.get('/api/dishes').catch(() => []),
-        api.get('/api/tags').catch(() => []),
-    ]);
+function applyDishes(list) {
+    allDishes = Array.isArray(list) ? [...list] : [];
     allDishes.sort((a, b) => a.name.localeCompare(b.name));
+}
+function applyTags(list) {
+    allTags = Array.isArray(list) ? [...list] : [];
     allTags.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function loadAll() {
+    const [d, t] = await Promise.all([
+        cachedGet('/api/dishes', (fresh) => {
+            applyDishes(fresh);
+            renderTagFilter();
+            renderDishes();
+        }).catch(() => []),
+        cachedGet('/api/tags', (fresh) => {
+            applyTags(fresh);
+            renderTagFilter();
+            renderDishes();
+        }).catch(() => []),
+    ]);
+    applyDishes(d);
+    applyTags(t);
     renderTagFilter();
     renderDishes();
 }
@@ -199,6 +216,7 @@ async function saveDish() {
             toast('Dish added', 'success');
         }
         closeModal(els.dishModal);
+        cache.set('GET:/api/dishes', null);
         await loadAll();
     } catch (e) {
         toast(e.message || 'Could not save dish', 'error');
@@ -214,6 +232,8 @@ async function deleteDish() {
         await api.del(`/api/dishes/${editingDish.id}`);
         toast('Dish deleted', 'info');
         closeModal(els.dishModal);
+        cache.set('GET:/api/dishes', null);
+        cache.set('GET:/api/meals', null);
         await loadAll();
     } catch (e) {
         toast(e.message || 'Could not delete dish', 'error');
@@ -242,6 +262,7 @@ function renderExistingTags() {
             try {
                 await api.del(`/api/tags/${b.dataset.id}`);
                 toast('Tag deleted', 'info');
+                cache.set('GET:/api/tags', null);
                 await loadAll();
                 renderExistingTags();
             } catch (e) {
@@ -258,6 +279,7 @@ async function saveNewTag() {
     try {
         await api.post('/api/tags', { name });
         els.newTagName.value = '';
+        cache.set('GET:/api/tags', null);
         await loadAll();
         renderExistingTags();
         toast('Tag added', 'success');

--- a/family.html
+++ b/family.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Settings · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=22" />
+    <link rel="stylesheet" href="styles.css?v=23" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#072444" />
     <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
           referrerpolicy="no-referrer" />
 </head>
@@ -22,7 +23,7 @@
     <nav class="bottom-nav"></nav>
 
     <script type="module">
-        import { api, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser } from './app.js?v=22';
+        import { api, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser } from './app.js?v=23';
 
         function escapeHtml(s) {
             return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));

--- a/grocery.html
+++ b/grocery.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Grocery List · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=22" />
+    <link rel="stylesheet" href="styles.css?v=23" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#072444" />
     <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
           referrerpolicy="no-referrer" />
 </head>
@@ -28,6 +29,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="grocery.js?v=22"></script>
+    <script type="module" src="grocery.js?v=23"></script>
 </body>
 </html>

--- a/grocery.js
+++ b/grocery.js
@@ -1,4 +1,4 @@
-import { api, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser } from './app.js?v=22';
+import { api, cache, cachedGet, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser } from './app.js?v=23';
 
 let groceryItems = []; // [{ name, totalQuantity, unit, haveIt, dishIds }]
 let allDishes = [];
@@ -18,62 +18,79 @@ function pluralizeUnit(unit, quantity) {
     return unit + 's';
 }
 
+function computeGroceryItems(meals, dishes) {
+    allDishes = dishes || [];
+    const today = new Date();
+    const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+
+    const dishesByName = new Map((dishes || []).map((d) => [d.name, d]));
+    const acc = {};
+
+    for (const [dateStr, dishName] of Object.entries(meals || {})) {
+        const t = new Date(dateStr).getTime();
+        if (isNaN(t) || t < startOfToday) continue;
+        const dish = dishesByName.get(dishName);
+        if (!dish || !dish.ingredients) continue;
+        for (const ing of Object.values(dish.ingredients)) {
+            const cleanName = (ing.name || '').toLowerCase().trim();
+            if (!cleanName) continue;
+            const q = (ing.quantity || '').toString();
+            const qtyMatch = q.match(/[\d.]+/);
+            const unitMatch = q.match(/[a-zA-Z]+/);
+            const qty = qtyMatch ? parseFloat(qtyMatch[0]) : 1;
+            const unit = unitMatch ? unitMatch[0] : '';
+            if (!acc[cleanName]) {
+                acc[cleanName] = {
+                    name: cleanName,
+                    totalQuantity: 0,
+                    unit: '',
+                    haveIt: false,
+                    dishIds: [],
+                };
+            }
+            acc[cleanName].totalQuantity += isNaN(qty) ? 0 : qty;
+            if (unit && !acc[cleanName].unit) acc[cleanName].unit = unit;
+            acc[cleanName].haveIt = acc[cleanName].haveIt || !!ing.haveIt;
+            if (!acc[cleanName].dishIds.includes(dish.id)) acc[cleanName].dishIds.push(dish.id);
+        }
+    }
+
+    groceryItems = Object.values(acc).sort((a, b) => {
+        if (a.haveIt !== b.haveIt) return a.haveIt ? 1 : -1;
+        return a.name.localeCompare(b.name);
+    });
+}
+
 async function buildList() {
-    els.wrap.innerHTML = `
-        <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
-        <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
-        <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
-    `;
+    const cachedMeals = cache.get('GET:/api/meals');
+    const cachedDishes = cache.get('GET:/api/dishes');
+    const haveCache = cachedMeals !== null && cachedMeals !== undefined && cachedDishes !== null && cachedDishes !== undefined;
+
+    if (haveCache) {
+        computeGroceryItems(cachedMeals, cachedDishes);
+        render();
+    } else {
+        els.wrap.innerHTML = `
+            <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
+            <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
+            <div class="skel" style="height: 64px; margin-bottom: 8px;"></div>
+        `;
+    }
+
     try {
         const [meals, dishes] = await Promise.all([
-            api.get('/api/meals').catch(() => ({})),
-            api.get('/api/dishes').catch(() => []),
+            api.get('/api/meals').then((d) => { cache.set('GET:/api/meals', d); return d; }).catch(() => ({})),
+            api.get('/api/dishes').then((d) => { cache.set('GET:/api/dishes', d); return d; }).catch(() => []),
         ]);
-        allDishes = dishes;
-
-        const today = new Date();
-        const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
-
-        const dishesByName = new Map(dishes.map((d) => [d.name, d]));
-        const acc = {};
-
-        for (const [dateStr, dishName] of Object.entries(meals)) {
-            const t = new Date(dateStr).getTime();
-            if (isNaN(t) || t < startOfToday) continue;
-            const dish = dishesByName.get(dishName);
-            if (!dish || !dish.ingredients) continue;
-            for (const ing of Object.values(dish.ingredients)) {
-                const cleanName = (ing.name || '').toLowerCase().trim();
-                if (!cleanName) continue;
-                const q = (ing.quantity || '').toString();
-                const qtyMatch = q.match(/[\d.]+/);
-                const unitMatch = q.match(/[a-zA-Z]+/);
-                const qty = qtyMatch ? parseFloat(qtyMatch[0]) : 1;
-                const unit = unitMatch ? unitMatch[0] : '';
-                if (!acc[cleanName]) {
-                    acc[cleanName] = {
-                        name: cleanName,
-                        totalQuantity: 0,
-                        unit: '',
-                        haveIt: false,
-                        dishIds: [],
-                    };
-                }
-                acc[cleanName].totalQuantity += isNaN(qty) ? 0 : qty;
-                if (unit && !acc[cleanName].unit) acc[cleanName].unit = unit;
-                acc[cleanName].haveIt = acc[cleanName].haveIt || !!ing.haveIt;
-                if (!acc[cleanName].dishIds.includes(dish.id)) acc[cleanName].dishIds.push(dish.id);
-            }
-        }
-
-        groceryItems = Object.values(acc).sort((a, b) => {
-            // Unchecked first, then alpha
-            if (a.haveIt !== b.haveIt) return a.haveIt ? 1 : -1;
-            return a.name.localeCompare(b.name);
-        });
+        const sameMeals = haveCache && JSON.stringify(meals) === JSON.stringify(cachedMeals);
+        const sameDishes = haveCache && JSON.stringify(dishes) === JSON.stringify(cachedDishes);
+        if (haveCache && sameMeals && sameDishes) return;
+        computeGroceryItems(meals, dishes);
         render();
     } catch (e) {
-        els.wrap.innerHTML = `<div class="empty-state"><div class="icon"><i class="fas fa-exclamation-triangle"></i></div><h3>Could not load list</h3><p>${escapeHtml(e.message)}</p></div>`;
+        if (!haveCache) {
+            els.wrap.innerHTML = `<div class="empty-state"><div class="icon"><i class="fas fa-exclamation-triangle"></i></div><h3>Could not load list</h3><p>${escapeHtml(e.message)}</p></div>`;
+        }
     }
 }
 
@@ -149,6 +166,7 @@ async function onToggle(idx, checked) {
             }
             if (modified) await api.put(`/api/dishes/${dish.id}`, dish);
         }
+        cache.set('GET:/api/dishes', allDishes);
     } catch (e) {
         toast(e.message || 'Could not save change', 'error');
     }
@@ -169,6 +187,7 @@ async function clearAll() {
             }
             if (modified) await api.put(`/api/dishes/${dish.id}`, dish);
         }
+        cache.set('GET:/api/dishes', allDishes);
         toast('List reset', 'info');
         await buildList();
     } catch (e) {

--- a/index.html
+++ b/index.html
@@ -4,13 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Calendar · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=22" />
+    <link rel="stylesheet" href="styles.css?v=23" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#072444" />
     <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-startup-image" href="launch.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
           referrerpolicy="no-referrer" />
 </head>
@@ -57,6 +58,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="script.js?v=22"></script>
+    <script type="module" src="script.js?v=23"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Sign in · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=22" />
+    <link rel="stylesheet" href="styles.css?v=23" />
     <link rel="manifest" href="manifest.json" />
     <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
@@ -41,7 +41,7 @@
     </div>
 
     <script type="module">
-        import { api, toast } from './app.js?v=22';
+        import { api, toast } from './app.js?v=23';
 
         // If already signed in, bounce to home
         api.get('/api/auth/me').then(({ user }) => {

--- a/register.html
+++ b/register.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Create account · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=22" />
+    <link rel="stylesheet" href="styles.css?v=23" />
     <link rel="manifest" href="manifest.json" />
     <link rel="icon" href="icon-180x180.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180x180.png" />
@@ -68,7 +68,7 @@
     </div>
 
     <script type="module">
-        import { api, toast } from './app.js?v=22';
+        import { api, toast } from './app.js?v=23';
 
         api.get('/api/auth/me').then(({ user }) => {
             if (user) location.href = user.familyId ? '/' : '/family';

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-import { api, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser } from './app.js?v=22';
+import { api, cache, cachedGet, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser } from './app.js?v=23';
 
 let currentDate = new Date();
 let meals = {};
@@ -23,7 +23,10 @@ function formatDateLong(dateKey) {
 
 async function loadMeals() {
     try {
-        meals = (await api.get('/api/meals')) || {};
+        meals = (await cachedGet('/api/meals', (fresh) => {
+            meals = fresh || {};
+            renderCalendar();
+        })) || {};
     } catch {
         meals = {};
     }
@@ -31,7 +34,11 @@ async function loadMeals() {
 
 async function loadDishes() {
     try {
-        dishes = (await api.get('/api/dishes')) || [];
+        dishes = (await cachedGet('/api/dishes', (fresh) => {
+            dishes = Array.isArray(fresh) ? [...fresh] : [];
+            dishes.sort((a, b) => a.name.localeCompare(b.name));
+        })) || [];
+        dishes = [...dishes];
         dishes.sort((a, b) => a.name.localeCompare(b.name));
     } catch {
         dishes = [];
@@ -124,6 +131,7 @@ async function pickDish(name) {
     try {
         await api.post('/api/meals', { date: activeDateKey, dishName: name });
         meals[activeDateKey] = name;
+        cache.set('GET:/api/meals', meals);
         renderCalendar();
         closeModal(els.modal);
         toast(`Saved ${capitalizeWords(name)} for ${formatDateLong(activeDateKey)}`, 'success');
@@ -141,6 +149,7 @@ async function clearMeal() {
     try {
         await api.del(`/api/meals/${activeDateKey}`);
         delete meals[activeDateKey];
+        cache.set('GET:/api/meals', meals);
         renderCalendar();
         closeModal(els.modal);
         toast('Meal cleared', 'info');

--- a/server.js
+++ b/server.js
@@ -587,7 +587,28 @@ app.use((req, res, next) => {
     next();
 });
 
-app.use(express.static(__dirname, { index: 'index.html', extensions: ['html'] }));
+app.use(
+    express.static(__dirname, {
+        index: 'index.html',
+        extensions: ['html'],
+        setHeaders(res, filePath) {
+            const base = path.basename(filePath);
+            if (base === 'sw.js') {
+                // Service worker must always be revalidated so updates roll out promptly.
+                res.setHeader('Cache-Control', 'no-cache');
+                return;
+            }
+            if (/\.html$/i.test(base)) {
+                // HTML changes rarely but we want quick rollout; SW handles offline.
+                res.setHeader('Cache-Control', 'no-cache');
+                return;
+            }
+            // Versioned (?v=) JS/CSS and binary assets: cache hard. The query
+            // string busts the cache when we bump versions in HTML.
+            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        },
+    })
+);
 
 // ─── Boot ────────────────────────────────────────────────────────────────────
 

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,72 @@
+// MealFinderrz service worker — caches the app shell so tab-switches are instant on iPhone.
+const VERSION = 'mfz-v23';
+const SHELL = [
+    '/',
+    '/dishes',
+    '/grocery',
+    '/family',
+    '/styles.css?v=23',
+    '/app.js?v=23',
+    '/script.js?v=23',
+    '/dishes.js?v=23',
+    '/grocery.js?v=23',
+    '/manifest.json',
+    '/icon-180x180.png',
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(VERSION).then((cache) =>
+            // Best-effort precache; missing entries shouldn't block install.
+            Promise.all(SHELL.map((url) => cache.add(url).catch(() => null)))
+        )
+    );
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches
+            .keys()
+            .then((keys) => Promise.all(keys.filter((k) => k !== VERSION).map((k) => caches.delete(k))))
+            .then(() => self.clients.claim())
+    );
+});
+
+self.addEventListener('fetch', (event) => {
+    const req = event.request;
+    if (req.method !== 'GET') return;
+
+    const url = new URL(req.url);
+
+    // Never intercept API calls — the app handles freshness via sessionStorage.
+    if (url.pathname.startsWith('/api/')) return;
+
+    // Only handle same-origin and the FontAwesome CDN.
+    const sameOrigin = url.origin === self.location.origin;
+    const isFontAwesome = url.hostname === 'cdnjs.cloudflare.com';
+    if (!sameOrigin && !isFontAwesome) return;
+
+    event.respondWith(staleWhileRevalidate(req));
+});
+
+async function staleWhileRevalidate(req) {
+    const cache = await caches.open(VERSION);
+    const cached = await cache.match(req);
+    const networkPromise = fetch(req)
+        .then((res) => {
+            if (res && (res.ok || res.type === 'opaque')) {
+                cache.put(req, res.clone()).catch(() => {});
+            }
+            return res;
+        })
+        .catch(() => null);
+
+    if (cached) {
+        // Don't await — let the network refresh the cache for next time.
+        networkPromise;
+        return cached;
+    }
+    const fresh = await networkPromise;
+    return fresh || new Response('Offline', { status: 503, statusText: 'Offline' });
+}


### PR DESCRIPTION
Each tab is its own HTML page, so navigating between Dishes/Calendar/ Grocery did a full reload, an /api/auth/me roundtrip, and a refetch of all data — perceived as stutter on iPhone.

- Add a service worker (sw.js) that pre-caches the app shell and serves same-origin assets + the FontAwesome CDN stale-while-revalidate.
- Cache the current user and API GET responses in sessionStorage; pages now paint instantly from cache and silently revalidate in the background, re-rendering only if data changed.
- Set long-lived Cache-Control on versioned static assets and no-cache on HTML / sw.js so updates still roll out promptly.
- Add preconnect to cdnjs so the first paint is faster too.
- Bump asset version 22 -> 23.