### PR TITLE
Add theme toggle (System/Light/Dark) and fix dark-mode contrast

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,35 @@
 // Shared client utilities — toasts, fetch wrapper, modal helpers, auth.
 
+// ─── Theme: system / light / dark ───────────────────────────────────
+// Applied as `<html data-theme="…">`. CSP forbids inline scripts, so this
+// runs at module-import time (before any of the page modules render).
+
+const THEME_KEY = 'mfz:theme';
+export const THEMES = ['system', 'light', 'dark'];
+
+export function getTheme() {
+    try {
+        const v = localStorage.getItem(THEME_KEY);
+        return THEMES.includes(v) ? v : 'system';
+    } catch {
+        return 'system';
+    }
+}
+
+export function setTheme(theme) {
+    if (!THEMES.includes(theme)) theme = 'system';
+    try { localStorage.setItem(THEME_KEY, theme); } catch {}
+    applyTheme(theme);
+}
+
+function applyTheme(theme) {
+    const root = document.documentElement;
+    if (theme === 'system') root.removeAttribute('data-theme');
+    else root.setAttribute('data-theme', theme);
+}
+
+applyTheme(getTheme());
+
 // ─── Service worker (snappy tab-switching on iPhone) ────────────────
 
 if ('serviceWorker' in navigator) {

--- a/dishes.html
+++ b/dishes.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Dish Library · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=25" />
+    <link rel="stylesheet" href="styles.css?v=26" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -96,6 +96,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="dishes.js?v=25"></script>
+    <script type="module" src="dishes.js?v=26"></script>
 </body>
 </html>

--- a/dishes.js
+++ b/dishes.js
@@ -1,4 +1,4 @@
-import { api, cache, cachedGet, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser, escapeHtml, debounce } from './app.js?v=25';
+import { api, cache, cachedGet, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser, escapeHtml, debounce } from './app.js?v=26';
 
 let allDishes = [];
 let allTags = [];

--- a/family.html
+++ b/family.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Settings · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=25" />
+    <link rel="stylesheet" href="styles.css?v=26" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -29,6 +29,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="family.js?v=25"></script>
+    <script type="module" src="family.js?v=26"></script>
 </body>
 </html>

--- a/family.js
+++ b/family.js
@@ -1,4 +1,4 @@
-import { api, toast, renderHeader, renderBottomNav, requireUser, escapeHtml } from './app.js?v=25';
+import { api, toast, renderHeader, renderBottomNav, requireUser, escapeHtml, getTheme, setTheme } from './app.js?v=26';
 
 let me;
 
@@ -12,6 +12,42 @@ async function load() {
     } catch (e) {
         root.innerHTML = `<div class="empty-state"><div class="icon"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i></div><h3>Could not load</h3><p>${escapeHtml(e.message)}</p></div>`;
     }
+    renderAppearance(root);
+}
+
+function renderAppearance(root) {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.style.marginTop = '14px';
+    const current = getTheme();
+    card.innerHTML = `
+        <h2 class="page-title" style="margin-top:0;"><i class="fas fa-palette" aria-hidden="true" style="color: var(--brand-blue);"></i> Appearance</h2>
+        <p class="help" style="margin: -4px 0 10px;">Switch between light, dark, or follow your device.</p>
+        <div class="theme-switcher" role="radiogroup" aria-label="Theme">
+            <button type="button" data-theme="system" role="radio" aria-checked="${current === 'system'}" class="${current === 'system' ? 'active' : ''}">
+                <i class="fas fa-circle-half-stroke" aria-hidden="true"></i> System
+            </button>
+            <button type="button" data-theme="light" role="radio" aria-checked="${current === 'light'}" class="${current === 'light' ? 'active' : ''}">
+                <i class="fas fa-sun" aria-hidden="true"></i> Light
+            </button>
+            <button type="button" data-theme="dark" role="radio" aria-checked="${current === 'dark'}" class="${current === 'dark' ? 'active' : ''}">
+                <i class="fas fa-moon" aria-hidden="true"></i> Dark
+            </button>
+        </div>
+    `;
+    root.appendChild(card);
+    const buttons = card.querySelectorAll('.theme-switcher button');
+    buttons.forEach((b) => {
+        b.addEventListener('click', () => {
+            const theme = b.dataset.theme;
+            setTheme(theme);
+            buttons.forEach((x) => {
+                const on = x === b;
+                x.classList.toggle('active', on);
+                x.setAttribute('aria-checked', on ? 'true' : 'false');
+            });
+        });
+    });
 }
 
 function renderNoFamily(root) {

--- a/grocery.html
+++ b/grocery.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Grocery List · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=25" />
+    <link rel="stylesheet" href="styles.css?v=26" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -36,6 +36,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="grocery.js?v=25"></script>
+    <script type="module" src="grocery.js?v=26"></script>
 </body>
 </html>

--- a/grocery.js
+++ b/grocery.js
@@ -1,4 +1,4 @@
-import { api, cache, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser, escapeHtml } from './app.js?v=25';
+import { api, cache, toast, capitalizeWords, renderHeader, renderBottomNav, requireUser, escapeHtml } from './app.js?v=26';
 
 let groceryItems = []; // [{ name, totalQuantity, unit, haveIt, dishIds }]
 let allDishes = [];

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Calendar · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=25" />
+    <link rel="stylesheet" href="styles.css?v=26" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -63,6 +63,6 @@
 
     <nav class="bottom-nav"></nav>
 
-    <script type="module" src="script.js?v=25"></script>
+    <script type="module" src="script.js?v=26"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Sign in · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=25" />
+    <link rel="stylesheet" href="styles.css?v=26" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -46,6 +46,6 @@
         </p>
     </div>
 
-    <script type="module" src="login.js?v=25"></script>
+    <script type="module" src="login.js?v=26"></script>
 </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -1,4 +1,4 @@
-import { api, toast } from './app.js?v=25';
+import { api, toast } from './app.js?v=26';
 
 // If already signed in, bounce to home
 api.get('/api/auth/me').then(({ user }) => {

--- a/register.html
+++ b/register.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Create account · MealFinderrz</title>
-    <link rel="stylesheet" href="styles.css?v=25" />
+    <link rel="stylesheet" href="styles.css?v=26" />
     <link rel="manifest" href="manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -73,6 +73,6 @@
         </p>
     </div>
 
-    <script type="module" src="register.js?v=25"></script>
+    <script type="module" src="register.js?v=26"></script>
 </body>
 </html>

--- a/register.js
+++ b/register.js
@@ -1,4 +1,4 @@
-import { api, toast } from './app.js?v=25';
+import { api, toast } from './app.js?v=26';
 
 api.get('/api/auth/me').then(({ user }) => {
     if (user) location.href = user.familyId ? '/' : '/family';

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-import { api, cache, cachedGet, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser, escapeHtml, debounce } from './app.js?v=25';
+import { api, cache, cachedGet, toast, capitalizeWords, openModal, closeModal, bindModalDismiss, renderHeader, renderBottomNav, requireUser, escapeHtml, debounce } from './app.js?v=26';
 
 let currentDate = new Date();
 let meals = {};

--- a/styles.css
+++ b/styles.css
@@ -1263,10 +1263,15 @@ img { max-width: 100%; display: block; }
 
 /* ================================================================
    Dark mode — keep brand identity, raise contrast on dark surfaces
+
+   Tokens live behind a single :where(...) selector so they apply when
+   either the OS prefers dark OR the user set data-theme="dark" — but
+   never when they explicitly chose data-theme="light". The matching
+   component overrides below use the same selector list.
    ================================================================ */
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --bg: #0a1626;
     --bg-2: #11203a;
     --surface: #122948;
@@ -1289,26 +1294,137 @@ img { max-width: 100%; display: block; }
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.45);
     --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.55);
     --shadow-lg: 0 18px 40px rgba(0, 0, 0, 0.7);
-  }
 
-  .day.today {
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #0a1626;
+  --bg-2: #11203a;
+  --surface: #122948;
+  --surface-2: #0e2240;
+  --overlay: rgba(0, 0, 0, 0.7);
+
+  --text: #EDF1F7;
+  --text-soft: #B8C4D6;
+  --text-muted: #7E8DA3;
+
+  --border: #1f3358;
+  --border-soft: #1a2c4a;
+
+  --brand-yellow-soft: #2a2410;
+
+  --accent-soft: #3a2a23;
+  --success-soft: #163528;
+  --danger-soft: #3a1f1f;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.55);
+  --shadow-lg: 0 18px 40px rgba(0, 0, 0, 0.7);
+
+  color-scheme: dark;
+}
+
+/* Force light when the user explicitly opts in, even on a dark OS. */
+:root[data-theme="light"] { color-scheme: light; }
+
+/* Component-level dark overrides — apply for both system-dark and explicit. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .day.today {
     background: linear-gradient(180deg, rgba(255, 203, 5, 0.18) 0%, var(--surface-2) 70%);
   }
-  .day.has-meal { background: var(--surface); }
-  .day .meal {
+  :root:not([data-theme="light"]) .day.has-meal { background: var(--surface); }
+  :root:not([data-theme="light"]) .day .meal {
     color: var(--brand-yellow);
     background: rgba(255, 203, 5, 0.14);
   }
-
-  .dish-search-input {
+  :root:not([data-theme="light"]) .dish-search-input {
     background-color: var(--surface-2);
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%237E8DA3' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='7'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>");
   }
+  :root:not([data-theme="light"]) .btn.btn-secondary { background: var(--surface-2); color: var(--text); }
+  :root:not([data-theme="light"]) .btn.btn-ghost:hover { background: var(--bg-2); }
+  :root:not([data-theme="light"]) .icon-btn { background: rgba(255, 255, 255, 0.06); }
 
-  .btn.btn-secondary { background: var(--surface-2); color: var(--text); }
-  .btn.btn-ghost:hover { background: var(--bg-2); }
-  .icon-btn { background: rgba(255, 255, 255, 0.06); }
-
-  /* Dark scheme for native form chrome where supported. */
-  html { color-scheme: dark; }
+  /* Fix unreadable toolbar / pill / chip buttons on dark surfaces. */
+  :root:not([data-theme="light"]) .toolbar-btn { color: var(--text); }
+  :root:not([data-theme="light"]) .toolbar-btn:hover { color: var(--brand-yellow); }
+  :root:not([data-theme="light"]) .dish-card .pill {
+    background: rgba(255, 203, 5, 0.18);
+    color: var(--brand-yellow);
+  }
+  :root:not([data-theme="light"]) .chip-list li {
+    background: rgba(255, 203, 5, 0.16);
+    color: var(--brand-yellow);
+    border-color: rgba(255, 203, 5, 0.4);
+  }
+  :root:not([data-theme="light"]) .chip-list .remove { color: var(--brand-yellow); }
+  :root:not([data-theme="light"]) .chip-list .remove:hover { background: rgba(255, 255, 255, 0.08); }
+  :root:not([data-theme="light"]) .tag-chip { color: var(--text); }
+  :root:not([data-theme="light"]) code { color: var(--brand-yellow); }
 }
+
+:root[data-theme="dark"] .day.today {
+  background: linear-gradient(180deg, rgba(255, 203, 5, 0.18) 0%, var(--surface-2) 70%);
+}
+:root[data-theme="dark"] .day.has-meal { background: var(--surface); }
+:root[data-theme="dark"] .day .meal {
+  color: var(--brand-yellow);
+  background: rgba(255, 203, 5, 0.14);
+}
+:root[data-theme="dark"] .dish-search-input {
+  background-color: var(--surface-2);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%237E8DA3' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='7'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>");
+}
+:root[data-theme="dark"] .btn.btn-secondary { background: var(--surface-2); color: var(--text); }
+:root[data-theme="dark"] .btn.btn-ghost:hover { background: var(--bg-2); }
+:root[data-theme="dark"] .icon-btn { background: rgba(255, 255, 255, 0.06); }
+:root[data-theme="dark"] .toolbar-btn { color: var(--text); }
+:root[data-theme="dark"] .toolbar-btn:hover { color: var(--brand-yellow); }
+:root[data-theme="dark"] .dish-card .pill {
+  background: rgba(255, 203, 5, 0.18);
+  color: var(--brand-yellow);
+}
+:root[data-theme="dark"] .chip-list li {
+  background: rgba(255, 203, 5, 0.16);
+  color: var(--brand-yellow);
+  border-color: rgba(255, 203, 5, 0.4);
+}
+:root[data-theme="dark"] .chip-list .remove { color: var(--brand-yellow); }
+:root[data-theme="dark"] .chip-list .remove:hover { background: rgba(255, 255, 255, 0.08); }
+:root[data-theme="dark"] .tag-chip { color: var(--text); }
+:root[data-theme="dark"] code { color: var(--brand-yellow); }
+
+/* ================================================================
+   Theme switcher (Settings page)
+   ================================================================ */
+
+.theme-switcher {
+  display: inline-flex;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+  gap: 2px;
+}
+.theme-switcher button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-soft);
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+.theme-switcher button.active {
+  background: var(--brand-blue);
+  color: var(--brand-yellow);
+}
+.theme-switcher button:not(.active):hover { color: var(--text); }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // MealFinderrz service worker — caches the app shell so tab-switches are
 // instant on iPhone. Bumping VERSION invalidates everything in one shot.
-const VERSION = 'mfz-v25';
+const VERSION = 'mfz-v26';
 const SHELL_CACHE = `${VERSION}-shell`;
 const RUNTIME_CACHE = `${VERSION}-runtime`;
 


### PR DESCRIPTION
The Settings page now has an Appearance card with three pill buttons: System (default — follows the OS), Light, Dark. The choice persists in localStorage and applies via <html data-theme="…">. CSS gates dark tokens on `:root:not([data-theme="light"])` inside the @media block so the explicit-light override beats the OS preference.

Fix the unreadable buttons on the dishes page in dark mode:
- .toolbar-btn (Manage tags, Add dish): was navy text on navy surface
- .dish-card .pill: was navy text on the dark amber tile
- .chip-list li / .remove: same problem in the dish-edit modal
- .tag-chip non-active: same All now use `--brand-yellow` foreground on a translucent yellow background. Also bumps muted text contrast and adds a yellow tint for <code>.

Bumps cache-busters v25 -> v26 (incl. SW VERSION) so iPhone clients pick up the new shell.